### PR TITLE
wip 0.6 fixes

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -35,7 +35,7 @@ Keyword arguments:
 * `presorted::Bool`: If true, the indices are assumed to already be sorted and no sorting is done.
 * `copy::Bool`: If true, the storage for the new array will not be shared with the passed indices and data. If false (the default), the passed arrays will be copied only if necessary for sorting. The only way to guarantee sharing of data is to pass `presorted=true`.
 """
-function NDSparse{T,D,C}(I::Columns{D,C}, d::AbstractVector{T}; agg=nothing, presorted=false, copy=false)
+function NDSparse{T<:AbstractVector, D,C}(I::Columns{D,C}, d::T; agg=nothing, presorted=false, copy=false)
     length(I) == length(d) || error("index and data must have the same number of elements")
     # ensure index is a `Columns` that generates tuples
     dt = D
@@ -56,7 +56,7 @@ function NDSparse{T,D,C}(I::Columns{D,C}, d::AbstractVector{T}; agg=nothing, pre
             d = Base.copy(d)
         end
     end
-    nd = NDSparse{T,dt,C,typeof(d)}(I, d, similar(I,0), similar(d,0))
+    nd = NDSparse{eltype(T),dt,C,typeof(d)}(I, d, similar(I,0), similar(d,0))
     agg===nothing || aggregate!(agg, nd)
     return nd
 end
@@ -68,7 +68,10 @@ Construct an NDSparse array from columns. The last argument is the data column, 
 """
 function NDSparse(columns...; names=nothing, rest...)
     keys, data = columns[1:end-1], columns[end]
-    NDSparse(Columns(keys..., names=names), data; rest...)
+    keycols = Columns(keys..., names=names)
+    @show typeof(keycols) typeof(data)
+    @show rest
+    NDSparse(keycols, data; rest...)
 end
 
 similar(t::NDSparse) = NDSparse(similar(t.index), empty!(similar(t.data)))


### PR DESCRIPTION
Trying to fix #29 

there were a few easy issues in NamedTuples to get done first: https://github.com/blackrock/NamedTuples.jl/compare/master...shashi:0.6-compat?expand=1

then this happened:
```
julia> NDSparse(Columns(x = rand(4), y = rand(4)), Columns(observation = rand(1:2, 4), confidence=rand(4)));
ERROR: MethodError: no method matching NamedTuples._NT_xy{Array{Float64,1},Array{Float64,1}}(::Array{Float64,1}, ::Array{Float64,1})
The applicable method may be too new: running in world age 21611, while current world is 21613.
Stacktrace:
 [1] #Columns#14(::Array{Symbol,1}, ::Type{T} where T, ::Array{Float64,1}, ::Vararg{Array{Float64,1},N} where N) at /home/shashi/.julia/v0.6/IndexedTables/src/columns.jl:28
 [2] (::Core.#kw#Type)(::Array{Any,1}, ::Type{IndexedTables.Columns}, ::Array{Float64,1}, ::Array{Float64,1}) at ./<missing>:0
 [3] #Columns#15(::Array{Any,1}, ::Type{T} where T) at /home/shashi/.julia/v0.6/IndexedTables/src/columns.jl:32
 [4] (::Core.#kw#Type)(::Array{Any,1}, ::Type{IndexedTables.Columns}) at ./<missing>:0
```

I figured I can evade the world error by not using eval in the Columns constructor, I tried using a generated function on a tuple of Vals denoting the fields as in this diff. But! There's an eval in the NamedTuples constructor... So I get `cannot eval in a generated function` here.

I tried to employ the same plan of using `Val{Sym}`s and using `@generated` in named tuples creation, but then realized I can't create a type inside function scope so that wouldn't work.

I don't know if there's anything else that can be done to get this back up and running. These are some options I see:

Option 1: we can switch to `FixedSizeDict`s or something similar, but that comes with caveats:

- Indexing with symbols is type unstable but might get better with @vtjnash's Union type work.
- Indexing with `Val` is fine, but `x[Val{:y}]` is far from the ergonomics of `x.y`.
- There's a macro sugar `@get x.y`, but still relatively not nice.

Option 2: with a little help from Julia the language: (any one of)

- first-class named tuples support (favorite option)
- dot-overloading (least favorite)
- allow types in function scope

cc @JeffBezanson @vtjnash