### PR TITLE
RFC: Add a kw-arg method to aggregate_vec

### DIFF
--- a/src/query.jl
+++ b/src/query.jl
@@ -201,6 +201,30 @@ function aggregate_vec(fs::Vector, x::NDSparse)
 end
 
 """
+`aggregate_vec(x::NDSparse; funs...)`
+
+Combine adjacent rows with equal indices using multiple functions from vector to scalar.
+The result has multiple data columns, one for each function provided by `funs`.
+"""
+function aggregate_vec(x::NDSparse; funs...)
+    n = length(funs)
+    n == 0 && return x
+    datacols = Any[ _aggregate_vec(funs[i][2], x.index, x.data) for i = 1:n-1 ]
+    idx, lastcol = aggregate_vec_to(funs[n][2], x.index, x.data)
+    NDSparse(idx, Columns(datacols..., lastcol, names = [x[1] for x in funs]),
+             presorted=true)
+end
+function aggregate_vec(x::NDSparse, funs::Pair...)
+    n = length(funs)
+    n == 0 && return x
+    datacols = Any[ _aggregate_vec(funs[i][2], x.index, x.data) for i = 1:n-1 ]
+    idx, lastcol = aggregate_vec_to(funs[n][2], x.index, x.data)
+    NDSparse(idx, Columns(datacols..., lastcol, names = map(first, funs)),
+             presorted=true)
+end
+
+
+"""
 `convertdim(x::NDSparse, d::DimName, xlate; agg::Function, vecagg::Function, name)`
 
 Apply function or dictionary `xlate` to each index in the specified dimension.

--- a/test/test_query.jl
+++ b/test/test_query.jl
@@ -59,6 +59,12 @@ end
                              [1, 4, 3, 5, 2, 0], presorted=true)) ==
                     NDSparse([1, 1], [2, 3], Columns(maximum=[4, 5], minimum=[1, 0]))
 
+@test aggregate_vec(NDSparse([1, 1, 1, 1, 1, 1],
+                             [2, 2, 2, 3, 3, 3],
+                             [1, 4, 3, 5, 2, 0], presorted=true),
+                    maxv = maximum, minv = minimum) ==
+                    NDSparse([1, 1], [2, 3], Columns(maxv=[4, 5], minv=[1, 0]))
+
 @test convertdim(NDSparse([1, 1, 1, 1, 1, 1],
                           [0, 1, 2, 3, 4, 5],
                           [1, 4, 3, 5, 2, 0], presorted=true), 2, x->div(x,3), vecagg=maximum) ==


### PR DESCRIPTION
This makes it a bit nicer to perform multiple aggregations on groups.

```julia
tbl = NDSparse(rand(1:3, 10), rand(1:2, 10), rand(10))
aggregate_vec(tbl, max = maximum, q75 = x->quantile(x, 0.75))
```

I included two versions, one with Pairs and one with keyword arguments. I like the keyword arg version better.
