### PR TITLE
rename `NDSparse` to `IndexedTable`

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -6,11 +6,11 @@ using IndexedTables
 ###
 
 function copy_unflushed(cols, data)
-   NDSparse(Columns(map(c->similar(c, 0), cols)...), similar(data, 0), Columns(deepcopy(cols)...), copy(data))
+   IndexedTable(Columns(map(c->similar(c, 0), cols)...), similar(data, 0), Columns(deepcopy(cols)...), copy(data))
 end
 
 function copy_flushed(cols, data)
-   NDSparse(deepcopy(cols)..., copy(data))
+   IndexedTable(deepcopy(cols)..., copy(data))
 end
 
 ###
@@ -63,8 +63,8 @@ function build_suite(S, N, D, vect_size, cols, data, flushed_arr)
           vcat(rand(Int, sz), rand(sz), map(x->randstring(5), 1 : sz), bitrand(N - 3*sz))::Vector{Any}
        end
 
-       @bench "numeric" NDSparse(c..., d) setup=(c = deepcopy($cols); d = copy($numeric_data))
-       @bench "mixed" NDSparse(c..., d) setup=(c = deepcopy($cols); d = $mixed_data)
+       @bench "numeric" IndexedTable(c..., d) setup=(c = deepcopy($cols); d = copy($numeric_data))
+       @bench "mixed" IndexedTable(c..., d) setup=(c = deepcopy($cols); d = $mixed_data)
    end
 
    @benchgroup "Flush" ["Flush"] begin
@@ -93,9 +93,9 @@ function main()
    D = try parse(Int, ARGS[3]) catch 3 end                    # Number of dimensions.
    vect_size = try parse(Int, ARGS[4]) catch div(N, 10) end   # Size of vector indices
 
-   cols = [rand(1 : S, N) for _ in 1 : D]                     # Columns for NDSparse object
-   data = trues(N)                                            # Data for NDSparse object
-   flushed_arr = copy_flushed(cols, data)                     # NDSparse object)
+   cols = [rand(1 : S, N) for _ in 1 : D]                     # Columns for IndexedTable object
+   data = trues(N)                                            # Data for IndexedTable object
+   flushed_arr = copy_flushed(cols, data)                     # IndexedTable object)
 
    build_suite(S, N, D, vect_size, cols, data, flushed_arr)
 end

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -1,9 +1,9 @@
 # getindex
 
-getindex(t::NDSparse, idxs...) = (flush!(t); _getindex(t, idxs))
+getindex(t::IndexedTable, idxs...) = (flush!(t); _getindex(t, idxs))
 
-_getindex{T,D<:Tuple}(t::NDSparse{T,D}, idxs::D) = _getindex_scalar(t, idxs)
-_getindex(t::NDSparse, idxs::Tuple{Vararg{Real}}) = _getindex_scalar(t, idxs)
+_getindex{T,D<:Tuple}(t::IndexedTable{T,D}, idxs::D) = _getindex_scalar(t, idxs)
+_getindex(t::IndexedTable, idxs::Tuple{Vararg{Real}}) = _getindex_scalar(t, idxs)
 
 function _getindex_scalar(t, idxs)
     i = searchsorted(t.index, idxs)
@@ -50,7 +50,7 @@ function range_estimate(I::Columns, idxs)
     return r
 end
 
-function _getindex(t::NDSparse, idxs)
+function _getindex(t::IndexedTable, idxs)
     I = t.index
     cs = astuple(I.columns)
     if length(idxs) != length(I.columns)
@@ -61,18 +61,18 @@ function _getindex(t::NDSparse, idxs)
     end
     out = convert(Vector{Int32}, range_estimate(I, idxs))
     filter!(i->row_in(cs, i, idxs), out)
-    NDSparse(Columns(map(x->x[out], I.columns)), t.data[out], presorted=true)
+    IndexedTable(Columns(map(x->x[out], I.columns)), t.data[out], presorted=true)
 end
 
 # iterators over indices - lazy getindex
 
 """
-`where(arr::NDSparse, indices...)`
+`where(arr::IndexedTable, indices...)`
 
 Returns an iterator over data items where the given indices match. Accepts the
 same index arguments as `getindex`.
 """
-function where{N}(d::NDSparse, idxs::Vararg{Any,N})
+function where{N}(d::IndexedTable, idxs::Vararg{Any,N})
     I = d.index
     cs = astuple(I.columns)
     data = d.data
@@ -81,12 +81,12 @@ function where{N}(d::NDSparse, idxs::Vararg{Any,N})
 end
 
 """
-`update!(f::Function, arr::NDSparse, indices...)`
+`update!(f::Function, arr::IndexedTable, indices...)`
 
 Replace data values `x` with `f(x)` at each location that matches the given
 indices.
 """
-function update!{N}(f::Union{Function,Type}, d::NDSparse, idxs::Vararg{Any,N})
+function update!{N}(f::Union{Function,Type}, d::IndexedTable, idxs::Vararg{Any,N})
     I = d.index
     cs = astuple(I.columns)
     data = d.data
@@ -99,15 +99,15 @@ function update!{N}(f::Union{Function,Type}, d::NDSparse, idxs::Vararg{Any,N})
     d
 end
 
-pairs(d::NDSparse) = (d.index[i]=>d.data[i] for i in 1:length(d))
+pairs(d::IndexedTable) = (d.index[i]=>d.data[i] for i in 1:length(d))
 
 """
-`pairs(arr::NDSparse, indices...)`
+`pairs(arr::IndexedTable, indices...)`
 
 Similar to `where`, but returns an iterator giving `index=>value` pairs.
 `index` will be a tuple.
 """
-function pairs{N}(d::NDSparse, idxs::Vararg{Any,N})
+function pairs{N}(d::IndexedTable, idxs::Vararg{Any,N})
     I = d.index
     cs = astuple(I.columns)
     data = d.data
@@ -117,20 +117,20 @@ end
 
 # setindex!
 
-setindex!(t::NDSparse, rhs, idxs...) = _setindex!(t, rhs, idxs)
+setindex!(t::IndexedTable, rhs, idxs...) = _setindex!(t, rhs, idxs)
 
 # assigning to an explicit set of indices --- equivalent to merge!
 
-setindex!(t::NDSparse, rhs, I::Columns) = setindex!(t, fill(rhs, length(I)), I) # TODO avoid `fill`
+setindex!(t::IndexedTable, rhs, I::Columns) = setindex!(t, fill(rhs, length(I)), I) # TODO avoid `fill`
 
-setindex!(t::NDSparse, rhs::AbstractVector, I::Columns) = merge!(t, NDSparse(I, rhs, copy=false))
+setindex!(t::IndexedTable, rhs::AbstractVector, I::Columns) = merge!(t, IndexedTable(I, rhs, copy=false))
 
 # assigning a single item
 
-_setindex!{T,D}(t::NDSparse{T,D}, rhs::AbstractArray, idxs::D) = _setindex_scalar!(t, rhs, idxs)
-_setindex!(t::NDSparse, rhs::AbstractArray, idxs::Tuple{Vararg{Real}}) = _setindex_scalar!(t, rhs, idxs)
-_setindex!{T,D}(t::NDSparse{T,D}, rhs, idxs::D) = _setindex_scalar!(t, rhs, idxs)
-#_setindex!(t::NDSparse, rhs, idxs::Tuple{Vararg{Real}}) = _setindex_scalar!(t, rhs, idxs)
+_setindex!{T,D}(t::IndexedTable{T,D}, rhs::AbstractArray, idxs::D) = _setindex_scalar!(t, rhs, idxs)
+_setindex!(t::IndexedTable, rhs::AbstractArray, idxs::Tuple{Vararg{Real}}) = _setindex_scalar!(t, rhs, idxs)
+_setindex!{T,D}(t::IndexedTable{T,D}, rhs, idxs::D) = _setindex_scalar!(t, rhs, idxs)
+#_setindex!(t::IndexedTable, rhs, idxs::Tuple{Vararg{Real}}) = _setindex_scalar!(t, rhs, idxs)
 
 function _setindex_scalar!(t, rhs, idxs)
     push!(t.index_buffer, idxs)
@@ -140,10 +140,10 @@ end
 
 # vector assignment: works like a left join
 
-_setindex!(t::NDSparse, rhs::NDSparse, idxs::Tuple{Vararg{Real}}) = _setindex!(t, rhs.data, idxs)
-_setindex!(t::NDSparse, rhs::NDSparse, idxs) = _setindex!(t, rhs.data, idxs)
+_setindex!(t::IndexedTable, rhs::IndexedTable, idxs::Tuple{Vararg{Real}}) = _setindex!(t, rhs.data, idxs)
+_setindex!(t::IndexedTable, rhs::IndexedTable, idxs) = _setindex!(t, rhs.data, idxs)
 
-function _setindex!{T,D}(d::NDSparse{T,D}, rhs::AbstractArray, idxs)
+function _setindex!{T,D}(d::IndexedTable{T,D}, rhs::AbstractArray, idxs)
     for idx in idxs
         isa(idx, AbstractVector) && (issorted(idx) || error("indices must be sorted for ranged/vector indexing"))
     end
@@ -180,7 +180,7 @@ end
 
 # broadcast assignment of a single value into all matching locations
 
-function _setindex!{T,D}(d::NDSparse{T,D}, rhs, idxs)
+function _setindex!{T,D}(d::IndexedTable{T,D}, rhs, idxs)
     for idx in idxs
         isa(idx, AbstractVector) && (issorted(idx) || error("indices must be sorted for ranged/vector indexing"))
     end
@@ -198,14 +198,14 @@ function _setindex!{T,D}(d::NDSparse{T,D}, rhs, idxs)
 end
 
 """
-`flush!(arr::NDSparse)`
+`flush!(arr::IndexedTable)`
 
 Commit queued assignment operations, by sorting and merging the internal temporary buffer.
 """
-function flush!(t::NDSparse)
+function flush!(t::IndexedTable)
     if !isempty(t.data_buffer)
         # 1. form sorted array of temp values, preferring values added later (`right`)
-        temp = NDSparse(t.index_buffer, t.data_buffer, copy=false, agg=right)
+        temp = IndexedTable(t.index_buffer, t.data_buffer, copy=false, agg=right)
 
         # 2. merge in
         _merge!(t, temp)

--- a/src/query.jl
+++ b/src/query.jl
@@ -1,50 +1,50 @@
 filt_by_col!(f, col, indxs) = filter!(i->f(col[i]), indxs)
 
 """
-`select(arr::NDSparse, conditions::Pair...)`
+`select(arr::IndexedTable, conditions::Pair...)`
 
 Filter based on index columns. Conditions are accepted as column-function pairs.
 
 Example: `select(arr, 1 => x->x>10, 3 => x->x!=10 ...)`
 """
-function Base.select(arr::NDSparse, conditions::Pair...)
+function Base.select(arr::IndexedTable, conditions::Pair...)
     flush!(arr)
     indxs = [1:length(arr);]
     cols = arr.index.columns
     for (c,f) in conditions
         filt_by_col!(f, cols[c], indxs)
     end
-    NDSparse(Columns(map(x->x[indxs], cols)), arr.data[indxs], presorted=true)
+    IndexedTable(Columns(map(x->x[indxs], cols)), arr.data[indxs], presorted=true)
 end
 
 """
-`select(arr:NDSparse, which::DimName...; agg::Function)`
+`select(arr:IndexedTable, which::DimName...; agg::Function)`
 
 Select a subset of index columns. If the resulting array has duplicate index entries,
 `agg` is used to combine the values.
 """
-function Base.select(arr::NDSparse, which::DimName...; agg=nothing)
+function Base.select(arr::IndexedTable, which::DimName...; agg=nothing)
     flush!(arr)
-    NDSparse(Columns(arr.index.columns[[which...]]), arr.data, agg=agg, copy=true)
+    IndexedTable(Columns(arr.index.columns[[which...]]), arr.data, agg=agg, copy=true)
 end
 
 # Filter on data field
-function Base.filter(fn::Function, arr::NDSparse)
+function Base.filter(fn::Function, arr::IndexedTable)
     flush!(arr)
     data = arr.data
     indxs = filter(i->fn(data[i]), eachindex(data))
-    NDSparse(Columns(map(x->x[indxs], arr.index.columns)), data[indxs], presorted=true)
+    IndexedTable(Columns(map(x->x[indxs], arr.index.columns)), data[indxs], presorted=true)
 end
 
 # aggregation
 
 """
-`aggregate!(f::Function, arr::NDSparse)`
+`aggregate!(f::Function, arr::IndexedTable)`
 
 Combine adjacent rows with equal indices using the given 2-argument reduction function,
 in place.
 """
-function aggregate!(f, x::NDSparse)
+function aggregate!(f, x::IndexedTable)
     idxs, data = x.index, x.data
     n = length(idxs)
     newlen = 0
@@ -69,14 +69,14 @@ function aggregate!(f, x::NDSparse)
 end
 
 """
-`aggregate(f::Function, arr::NDSparse)`
+`aggregate(f::Function, arr::IndexedTable)`
 
 Combine adjacent rows with equal indices using the given 2-argument reduction function,
 returning the result in a new array.
 """
-function aggregate(f, x::NDSparse)
+function aggregate(f, x::IndexedTable)
     idxs, data = aggregate_to(f, x.index, x.data)
-    NDSparse(idxs, data, presorted=true, copy=false)
+    IndexedTable(idxs, data, presorted=true, copy=false)
 end
 
 # aggregate out of place, building up new indexes and data
@@ -175,33 +175,33 @@ function _aggregate_vec(f, idxs::Columns, data)
 end
 
 """
-`aggregate_vec(f::Function, x::NDSparse)`
+`aggregate_vec(f::Function, x::IndexedTable)`
 
 Combine adjacent rows with equal indices using a function from vector to scalar,
 e.g. `mean`.
 """
-function aggregate_vec(f, x::NDSparse)
+function aggregate_vec(f, x::IndexedTable)
     idxs, data = aggregate_vec_to(f, x.index, x.data)
-    NDSparse(idxs, data, presorted=true, copy=false)
+    IndexedTable(idxs, data, presorted=true, copy=false)
 end
 
 """
-`aggregate_vec(f::Vector{Function}, x::NDSparse)`
+`aggregate_vec(f::Vector{Function}, x::IndexedTable)`
 
 Combine adjacent rows with equal indices using multiple functions from vector to scalar.
 The result has multiple data columns, one for each function, named based on the functions.
 """
-function aggregate_vec(fs::Vector, x::NDSparse)
+function aggregate_vec(fs::Vector, x::IndexedTable)
     n = length(fs)
     n == 0 && return x
     datacols = Any[ _aggregate_vec(fs[i], x.index, x.data) for i = 1:n-1 ]
     idx, lastcol = aggregate_vec_to(fs[n], x.index, x.data)
-    NDSparse(idx, Columns(datacols..., lastcol, names = map(Symbol, fs)),
-             presorted=true)
+    IndexedTable(idx, Columns(datacols..., lastcol, names = map(Symbol, fs)),
+                 presorted=true)
 end
 
 """
-`convertdim(x::NDSparse, d::DimName, xlate; agg::Function, vecagg::Function, name)`
+`convertdim(x::IndexedTable, d::DimName, xlate; agg::Function, vecagg::Function, name)`
 
 Apply function or dictionary `xlate` to each index in the specified dimension.
 If the mapping is many-to-one, `agg` or `vecagg` is used to aggregate the results.
@@ -210,7 +210,7 @@ If `vecagg` is passed, it is used as a vector-to-scalar function to aggregate
 the data.
 `name` optionally specifies a new name for the translated dimension.
 """
-function convertdim(x::NDSparse, d::DimName, xlat; agg=nothing, vecagg=nothing, name=nothing)
+function convertdim(x::IndexedTable, d::DimName, xlat; agg=nothing, vecagg=nothing, name=nothing)
     cols = x.index.columns
     d2 = map(xlat, cols[d])
     n = fieldindex(cols, d)
@@ -220,20 +220,20 @@ function convertdim(x::NDSparse, d::DimName, xlat; agg=nothing, vecagg=nothing, 
         names[n] = name
     end
     if vecagg !== nothing
-        y = NDSparse(cols[1:n-1]..., d2, cols[n+1:end]..., x.data, copy=false, names=names)
+        y = IndexedTable(cols[1:n-1]..., d2, cols[n+1:end]..., x.data, copy=false, names=names)
         idxs, data = aggregate_vec_to(vecagg, y.index, y.data)
-        return NDSparse(idxs, data, copy=false)
+        return IndexedTable(idxs, data, copy=false)
     end
-    NDSparse(cols[1:n-1]..., d2, cols[n+1:end]..., x.data, agg=agg, copy=true, names=names)
+    IndexedTable(cols[1:n-1]..., d2, cols[n+1:end]..., x.data, agg=agg, copy=true, names=names)
 end
 
-convertdim(x::NDSparse, d::Int, xlat::Dict; agg=nothing, vecagg=nothing, name=nothing) = convertdim(x, d, i->xlat[i], agg=agg, vecagg=vecagg, name=name)
+convertdim(x::IndexedTable, d::Int, xlat::Dict; agg=nothing, vecagg=nothing, name=nothing) = convertdim(x, d, i->xlat[i], agg=agg, vecagg=vecagg, name=name)
 
-convertdim(x::NDSparse, d::Int, xlat, agg) = convertdim(x, d, xlat, agg=agg)
+convertdim(x::IndexedTable, d::Int, xlat, agg) = convertdim(x, d, xlat, agg=agg)
 
-sum(x::NDSparse) = sum(x.data)
+sum(x::IndexedTable) = sum(x.data)
 
-function reducedim(f, x::NDSparse, dims)
+function reducedim(f, x::IndexedTable, dims)
     keep = setdiff([1:ndims(x);], map(d->fieldindex(x.index.columns,d), dims))
     if isempty(keep)
         throw(ArgumentError("to remove all dimensions, use `reduce(f, A)`"))
@@ -241,15 +241,15 @@ function reducedim(f, x::NDSparse, dims)
     select(x, keep..., agg=f)
 end
 
-reducedim(f, x::NDSparse, dims::Symbol) = reducedim(f, x, [dims])
+reducedim(f, x::IndexedTable, dims::Symbol) = reducedim(f, x, [dims])
 
 """
-`reducedim_vec(f::Function, arr::NDSparse, dims)`
+`reducedim_vec(f::Function, arr::IndexedTable, dims)`
 
 Like `reducedim`, except uses a function mapping a vector of values to a scalar instead
 of a 2-argument scalar function.
 """
-function reducedim_vec(f, x::NDSparse, dims)
+function reducedim_vec(f, x::IndexedTable, dims)
     keep = setdiff([1:ndims(x);], map(d->fieldindex(x.index.columns,d), dims))
     if isempty(keep)
         throw(ArgumentError("to remove all dimensions, use `reduce(f, A)`"))
@@ -263,7 +263,7 @@ function reducedim_vec(f, x::NDSparse, dims)
         xd = x.data[p]
         d = _aggregate_vec!(f, idxs, xd)
     end
-    NDSparse(idxs, d, presorted=true, copy=false)
+    IndexedTable(idxs, d, presorted=true, copy=false)
 end
 
-reducedim_vec(f, x::NDSparse, dims::Symbol) = reducedim_vec(f, x, [dims])
+reducedim_vec(f, x::IndexedTable, dims::Symbol) = reducedim_vec(f, x, [dims])

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -19,8 +19,8 @@ let c = Columns([1,1,1,2,2], [1,2,4,3,5]),
     d = Columns([1,1,2,2,2], [1,3,1,4,5]),
     e = Columns([1,1,1], sort([rand(),0.5,rand()])),
     f = Columns([1,1,1], sort([rand(),0.5,rand()]))
-    @test merge(NDSparse(c,ones(5)),NDSparse(d,ones(5))).index == Columns([1,1,1,1,2,2,2,2],[1,2,3,4,1,3,4,5])
-    @test length(merge(NDSparse(e,ones(3)),NDSparse(f,ones(3)))) == 5
+    @test merge(IndexedTable(c,ones(5)),IndexedTable(d,ones(5))).index == Columns([1,1,1,1,2,2,2,2],[1,2,3,4,1,3,4,5])
+    @test length(merge(IndexedTable(e,ones(3)),IndexedTable(f,ones(3)))) == 5
     @test summary(c) == "Columns{Tuple{Int64,Int64}}"
 end
 
@@ -28,17 +28,17 @@ let c = Columns([1,1,1,2,2], [1,2,4,3,5]),
     d = Columns([1,1,2,2,2], [1,3,1,4,5]),
     e = Columns([1,1,1], sort([rand(),0.5,rand()])),
     f = Columns([1,1,1], sort([rand(),0.5,rand()]))
-    @test map(+,NDSparse(c,ones(5)),NDSparse(d,ones(5))).index == Columns([1,2],[1,5])
-    @test length(map(+,NDSparse(e,ones(3)),NDSparse(f,ones(3)))) == 1
+    @test map(+,IndexedTable(c,ones(5)),IndexedTable(d,ones(5))).index == Columns([1,2],[1,5])
+    @test length(map(+,IndexedTable(e,ones(3)),IndexedTable(f,ones(3)))) == 1
     @test eltype(c) == Tuple{Int,Int}
 end
 
 srand(123)
-A = NDSparse(rand(1:3,10), rand('A':'F',10), map(UInt8,rand(1:3,10)), collect(1:10), randn(10))
-B = NDSparse(map(UInt8,rand(1:3,10)), rand('A':'F',10), rand(1:3,10), randn(10))
-C = NDSparse(map(UInt8,rand(1:3,10)), rand(1:3,10), rand(1:3,10), randn(10))
+A = IndexedTable(rand(1:3,10), rand('A':'F',10), map(UInt8,rand(1:3,10)), collect(1:10), randn(10))
+B = IndexedTable(map(UInt8,rand(1:3,10)), rand('A':'F',10), rand(1:3,10), randn(10))
+C = IndexedTable(map(UInt8,rand(1:3,10)), rand(1:3,10), rand(1:3,10), randn(10))
 
-let a = NDSparse([12,21,32], [52,41,34], [11,53,150]), b = NDSparse([12,23,32], [52,43,34], [56,13,10])
+let a = IndexedTable([12,21,32], [52,41,34], [11,53,150]), b = IndexedTable([12,23,32], [52,43,34], [56,13,10])
     @test eltype(a) == Int
     @test sum(a) == 214
 
@@ -59,123 +59,123 @@ let a = NDSparse([12,21,32], [52,41,34], [11,53,150]), b = NDSparse([12,23,32], 
     @test length(c.index) == 2
     @test sum(map(-, c, c)) == 0
 
-    @test map(iseven, a) == NDSparse([12,21,32], [52,41,34], [false,false,true])
+    @test map(iseven, a) == IndexedTable([12,21,32], [52,41,34], [false,false,true])
 end
 
 let S = spdiagm(1:5)
-    nd = convert(NDSparse, S)
-    @test sum(S) == sum(nd) == sum(convert(NDSparse, full(S)))
+    nd = convert(IndexedTable, S)
+    @test sum(S) == sum(nd) == sum(convert(IndexedTable, full(S)))
 
     @test sum(broadcast(+, 10, nd)) == (sum(nd) + 10*nnz(S))
     @test sum(broadcast(+, nd, 10)) == (sum(nd) + 10*nnz(S))
     @test sum(broadcast(+, nd, nd)) == 2*(sum(nd))
 
     nd[1:5,1:5] = 2
-    @test nd == convert(NDSparse, spdiagm(fill(2, 5)))
+    @test nd == convert(IndexedTable, spdiagm(fill(2, 5)))
 end
 
 let S = sprand(10,10,.1), v = rand(10)
-    nd = convert(NDSparse, S)
-    ndv = convert(NDSparse,v)
-    @test broadcast(*, nd, ndv) == convert(NDSparse, S .* v)
+    nd = convert(IndexedTable, S)
+    ndv = convert(IndexedTable,v)
+    @test broadcast(*, nd, ndv) == convert(IndexedTable, S .* v)
     # test matching dimensions by name
-    ndt0 = convert(NDSparse, sparse(S .* (v')))
-    ndt = NDSparse(Columns(a=ndt0.index.columns[1], b=ndt0.index.columns[2]), ndt0.data, presorted=true)
+    ndt0 = convert(IndexedTable, sparse(S .* (v')))
+    ndt = IndexedTable(Columns(a=ndt0.index.columns[1], b=ndt0.index.columns[2]), ndt0.data, presorted=true)
     @test broadcast(*,
-                    NDSparse(Columns(a=nd.index.columns[1], b=nd.index.columns[2]), nd.data),
-                    NDSparse(Columns(b=ndv.index.columns[1]), ndv.data)) == ndt
+                    IndexedTable(Columns(a=nd.index.columns[1], b=nd.index.columns[2]), nd.data),
+                    IndexedTable(Columns(b=ndv.index.columns[1]), ndv.data)) == ndt
 end
 
 let a = rand(10), b = rand(10), c = rand(10)
-    @test NDSparse(a, b, c) == NDSparse(a, b, c)
+    @test IndexedTable(a, b, c) == IndexedTable(a, b, c)
     c2 = copy(c)
     c2[1] += 1
-    @test NDSparse(a, b, c) != NDSparse(a, b, c2)
+    @test IndexedTable(a, b, c) != IndexedTable(a, b, c2)
     b2 = copy(b)
     b2[1] += 1
-    @test NDSparse(a, b, c) != NDSparse(a, b2, c)
+    @test IndexedTable(a, b, c) != IndexedTable(a, b2, c)
 end
 
 let a = rand(10), b = rand(10), c = rand(10), d = rand(10)
-    local nd = NDSparse(a,b,c,d)
-    @test permutedims(nd,[3,1,2]) == NDSparse(c,a,b,d)
+    local nd = IndexedTable(a,b,c,d)
+    @test permutedims(nd,[3,1,2]) == IndexedTable(c,a,b,d)
     @test_throws ArgumentError permutedims(nd, [1,2])
     @test_throws ArgumentError permutedims(nd, [1,3])
     @test_throws ArgumentError permutedims(nd, [1,2,2])
 end
 
 let r=1:5, s=1:2:5
-    A = NDSparse([r;], [r;], [r;])
-    @test A[s, :] == NDSparse([s;], [s;], [s;])
+    A = IndexedTable([r;], [r;], [r;])
+    @test A[s, :] == IndexedTable([s;], [s;], [s;])
     @test_throws ErrorException A[s, :, :]
 end
 
-let a = NDSparse([1,2,2,2], [1,2,3,4], [10,9,8,7])
+let a = IndexedTable([1,2,2,2], [1,2,3,4], [10,9,8,7])
     @test a[1,1] == 10
     @test a[2,3] == 8
     #@test_throws ErrorException a[2]
-    @test a[2,:] == NDSparse([2,2,2], [2,3,4], [9,8,7])
-    @test a[:,1] == NDSparse([1], [1], [10])
+    @test a[2,:] == IndexedTable([2,2,2], [2,3,4], [9,8,7])
+    @test a[:,1] == IndexedTable([1], [1], [10])
     @test collect(where(a, 2, :)) == [9,8,7]
     @test collect(pairs(a)) == [(1,1)=>10, (2,2)=>9, (2,3)=>8, (2,4)=>7]
     @test first(pairs(a, :, 3)) == ((2,3)=>8)
 
     update!(x->x+10, a, 2, :)
-    @test a == NDSparse([1,2,2,2], [1,2,3,4], [10,19,18,17])
+    @test a == IndexedTable([1,2,2,2], [1,2,3,4], [10,19,18,17])
 
     a[2,2:3] = 77
-    @test a == NDSparse([1,2,2,2], [1,2,3,4], [10,77,77,17])
+    @test a == IndexedTable([1,2,2,2], [1,2,3,4], [10,77,77,17])
 end
 
-let a = NDSparse([1,2,2,2], [1,2,3,4], zeros(4))
+let a = IndexedTable([1,2,2,2], [1,2,3,4], zeros(4))
     a2 = copy(a); a3 = copy(a)
     #a[2,:] = 1
-    #@test a == NDSparse([1,2,2,2], [1,2,3,4], Float64[0,1,1,1])
+    #@test a == IndexedTable([1,2,2,2], [1,2,3,4], Float64[0,1,1,1])
     a2[2,[2,3]] = 1
-    @test a2 == NDSparse([1,2,2,2], [1,2,3,4], Float64[0,1,1,0])
+    @test a2 == IndexedTable([1,2,2,2], [1,2,3,4], Float64[0,1,1,0])
     a3[2,[2,3]] = [8,9]
-    @test a3 == NDSparse([1,2,2,2], [1,2,3,4], Float64[0,8,9,0])
+    @test a3 == IndexedTable([1,2,2,2], [1,2,3,4], Float64[0,8,9,0])
 end
 
 # issue #15
-let a = NDSparse([1,2,3,4], [1,2,3,4], [1,2,3,4])
+let a = IndexedTable([1,2,3,4], [1,2,3,4], [1,2,3,4])
     a[5,5] = 5
     a[5,5] = 6
     @test a[5,5] == 6
 end
 
-let a = NDSparse([1,2,2,3,4,5], [1,2,2,3,4,5], [1,2,20,3,4,5], agg=+)
-    @test a == NDSparse([1,2,3,4,5], [1,2,3,4,5], [1,22,3,4,5])
+let a = IndexedTable([1,2,2,3,4,5], [1,2,2,3,4,5], [1,2,20,3,4,5], agg=+)
+    @test a == IndexedTable([1,2,3,4,5], [1,2,3,4,5], [1,22,3,4,5])
 end
 
 let a = rand(5,5,5)
     for dims in ([2,3], [1], [2])
         r = squeeze(reducedim(+, a, dims), (dims...,))
-        asnd = convert(NDSparse,a)
+        asnd = convert(IndexedTable,a)
         b = reducedim(+, asnd, dims)
         bv = reducedim_vec(sum, asnd, dims)
-        c = convert(NDSparse, r)
+        c = convert(IndexedTable, r)
         @test b.index == c.index == bv.index
         @test_approx_eq b.data c.data
         @test_approx_eq bv.data c.data
     end
-    @test_throws ArgumentError reducedim(+, convert(NDSparse,a), [1,2,3])
+    @test_throws ArgumentError reducedim(+, convert(IndexedTable,a), [1,2,3])
 end
 
 for a in (rand(2,2), rand(3,5))
-    nd = convert(NDSparse, a)
-    @test nd == convert(NDSparse, sparse(a))
+    nd = convert(IndexedTable, a)
+    @test nd == convert(IndexedTable, sparse(a))
     for (I,d) in zip(nd.index, nd.data)
         @test a[I...] == d
     end
 end
 
-_colnames(x::NDSparse) = keys(x.index.columns)
+_colnames(x::IndexedTable) = keys(x.index.columns)
 
-@test _colnames(NDSparse(ones(2),ones(2),ones(2),names=[:a,:b])) == [:a, :b]
-@test _colnames(NDSparse(Columns(x=ones(2),y=ones(2)), ones(2))) == [:x, :y]
+@test _colnames(IndexedTable(ones(2),ones(2),ones(2),names=[:a,:b])) == [:a, :b]
+@test _colnames(IndexedTable(Columns(x=ones(2),y=ones(2)), ones(2))) == [:x, :y]
 
-let x = NDSparse(Columns(x = [1,2,3], y = [4,5,6], z = [7,8,9]), [10,11,12])
+let x = IndexedTable(Columns(x = [1,2,3], y = [4,5,6], z = [7,8,9]), [10,11,12])
     names = [:x, :y, :z]
     @test _colnames(x) == names
     @test _colnames(filter(a->a==11, x)) == names
@@ -183,39 +183,39 @@ let x = NDSparse(Columns(x = [1,2,3], y = [4,5,6], z = [7,8,9]), [10,11,12])
     @test _colnames(select(x, :y)) == [:y]
     @test _colnames(select(x, :x=>a->a>1, :z=>a->a>7)) == names
     @test _colnames(x[1:2, 4:5, 8:9]) == names
-    @test convertdim(x, :y, a->0) == NDSparse(Columns([1,2,3], [0,0,0], [7,8,9]), [10,11,12])
-    @test convertdim(x, :y, a->0, name=:yy) == NDSparse(Columns(x=[1,2,3], yy=[0,0,0], z=[7,8,9]), [10,11,12])
+    @test convertdim(x, :y, a->0) == IndexedTable(Columns([1,2,3], [0,0,0], [7,8,9]), [10,11,12])
+    @test convertdim(x, :y, a->0, name=:yy) == IndexedTable(Columns(x=[1,2,3], yy=[0,0,0], z=[7,8,9]), [10,11,12])
 end
 
 # test showing
-@test repr(NDSparse([1,2,3],[3,2,1],Float64[4,5,6])) == """
+@test repr(IndexedTable([1,2,3],[3,2,1],Float64[4,5,6])) == """
 ─────┬────
 1  3 │ 4.0
 2  2 │ 5.0
 3  1 │ 6.0"""
 
-@test repr(NDSparse(Columns(a=[1,2,3],test=[3,2,1]),Float64[4,5,6])) == """
+@test repr(IndexedTable(Columns(a=[1,2,3],test=[3,2,1]),Float64[4,5,6])) == """
 a  test │ 
 ────────┼────
 1  3    │ 4.0
 2  2    │ 5.0
 3  1    │ 6.0"""
 
-@test repr(NDSparse(Columns(a=[1,2,3],test=[3,2,1]),Columns(x=Float64[4,5,6],y=[9,8,7]))) == """
+@test repr(IndexedTable(Columns(a=[1,2,3],test=[3,2,1]),Columns(x=Float64[4,5,6],y=[9,8,7]))) == """
 a  test │ x    y
 ────────┼───────
 1  3    │ 4.0  9
 2  2    │ 5.0  8
 3  1    │ 6.0  7"""
 
-@test repr(NDSparse([1,2,3],[3,2,1],Columns(x=Float64[4,5,6],y=[9,8,7]))) == """
+@test repr(IndexedTable([1,2,3],[3,2,1],Columns(x=Float64[4,5,6],y=[9,8,7]))) == """
      │ x    y
 ─────┼───────
 1  3 │ 4.0  9
 2  2 │ 5.0  8
 3  1 │ 6.0  7"""
 
-@test repr(NDSparse([1:21;],ones(Int,21))) == """
+@test repr(IndexedTable([1:21;],ones(Int,21))) == """
 ───┬──
 1  │ 1
 2  │ 1
@@ -243,6 +243,6 @@ let x = Columns([6,5,4,3,2,2,1],[4,4,4,4,4,4,4],[1,2,3,4,5,6,7])
     @test issorted(x[sortperm(x)])
 end
 
-let x = NDSparse([1,2],[3,4],[:a,:b],[3,5])
-    @test x[1,:,:a] == NDSparse([1],[3],[:a],[3])
+let x = IndexedTable([1,2],[3,4],[:a,:b],[3,5])
+    @test x[1,:,:a] == IndexedTable([1],[3],[:a],[3])
 end

--- a/test/test_query.jl
+++ b/test/test_query.jl
@@ -1,16 +1,16 @@
 using Base.Test
 using IndexedTables
 
-let a = NDSparse([12,21,32], [52,41,34], [11,53,150]), b = NDSparse([12,23,32], [52,43,34], [56,13,10])
+let a = IndexedTable([12,21,32], [52,41,34], [11,53,150]), b = IndexedTable([12,23,32], [52,43,34], [56,13,10])
     c = naturaljoin(a, b, +)
     @test c[12,52] == 67
     @test c[32,34] == 160
     @test length(c.index) == 2
-    @test naturaljoin(a, b) == NDSparse([12,32], [52,34], Columns([11,150], [56,10]))
+    @test naturaljoin(a, b) == IndexedTable([12,32], [52,34], Columns([11,150], [56,10]))
 
-    c = NDSparse([12,32], [52,34], Columns([0,1], [2,3]))
-    @test naturaljoin(a, c) == NDSparse([12,32], [52,34], Columns([11,150], [0,1], [2,3]))
-    @test naturaljoin(c, a) == NDSparse([12,32], [52,34], Columns([0,1], [2,3], [11,150]))
+    c = IndexedTable([12,32], [52,34], Columns([0,1], [2,3]))
+    @test naturaljoin(a, c) == IndexedTable([12,32], [52,34], Columns([11,150], [0,1], [2,3]))
+    @test naturaljoin(c, a) == IndexedTable([12,32], [52,34], Columns([0,1], [2,3], [11,150]))
 
     c = select(a, 1=>x->x<30, 2=>x->x>40)
     @test c[12,52] == 11
@@ -22,56 +22,56 @@ let a = NDSparse([12,21,32], [52,41,34], [11,53,150]), b = NDSparse([12,23,32], 
     @test length(c.index) == 1
 end
 
-let a = NDSparse([1,1,2,2], [1,2,1,2], [6,7,8,9])
-    @test select(a, 1, agg=+) == NDSparse([1,2], [13,17])
-    @test select(a, 2, agg=+) == NDSparse([1,2], [14,16])
+let a = IndexedTable([1,1,2,2], [1,2,1,2], [6,7,8,9])
+    @test select(a, 1, agg=+) == IndexedTable([1,2], [13,17])
+    @test select(a, 2, agg=+) == IndexedTable([1,2], [14,16])
 end
 
-@test leftjoin(NDSparse([1,1,1,2], [2,3,4,4], [5,6,7,8]),
-               NDSparse([1,1,3],   [2,4,4],   [9,10,12])) ==
-                   NDSparse([1,1,1,2], [2,3,4,4], [9, 6, 10, 8])
+@test leftjoin(IndexedTable([1,1,1,2], [2,3,4,4], [5,6,7,8]),
+               IndexedTable([1,1,3],   [2,4,4],   [9,10,12])) ==
+                   IndexedTable([1,1,1,2], [2,3,4,4], [9, 6, 10, 8])
 
-@test leftjoin(NDSparse([1,1,1,2], [2,3,4,4], [5,6,7,8]),
-               NDSparse([1,1,2],   [2,4,4],   [9,10,12])) ==
-                   NDSparse([1,1,1,2], [2,3,4,4], [9, 6, 10, 12])
+@test leftjoin(IndexedTable([1,1,1,2], [2,3,4,4], [5,6,7,8]),
+               IndexedTable([1,1,2],   [2,4,4],   [9,10,12])) ==
+                   IndexedTable([1,1,1,2], [2,3,4,4], [9, 6, 10, 12])
 
-@test asofjoin(NDSparse([:msft,:ibm,:ge], [1,3,4], [100,200,150]),
-               NDSparse([:ibm,:msft,:msft,:ibm], [0,0,0,2], [100,99,101,98])) ==
-                   NDSparse([:msft,:ibm,:ge], [1,3,4], [101, 98, 150])
+@test asofjoin(IndexedTable([:msft,:ibm,:ge], [1,3,4], [100,200,150]),
+               IndexedTable([:ibm,:msft,:msft,:ibm], [0,0,0,2], [100,99,101,98])) ==
+                   IndexedTable([:msft,:ibm,:ge], [1,3,4], [101, 98, 150])
 
-@test asofjoin(NDSparse([:AAPL, :IBM, :MSFT], [45, 512, 454], [63, 93, 54]),
-               NDSparse([:AAPL, :MSFT, :AAPL], [547,250,34], [88,77,30])) ==
-                   NDSparse([:AAPL, :MSFT, :IBM], [45, 454, 512], [30, 77, 93])
+@test asofjoin(IndexedTable([:AAPL, :IBM, :MSFT], [45, 512, 454], [63, 93, 54]),
+               IndexedTable([:AAPL, :MSFT, :AAPL], [547,250,34], [88,77,30])) ==
+                   IndexedTable([:AAPL, :MSFT, :IBM], [45, 454, 512], [30, 77, 93])
 
-@test asofjoin(NDSparse([:aapl,:ibm,:msft,:msft],[1,1,1,3],[4,5,6,7]),
-               NDSparse([:aapl,:ibm,:msft],[0,0,0],[8,9,10])) ==
-                   NDSparse([:aapl,:ibm,:msft,:msft],[1,1,1,3],[8,9,10,10])
+@test asofjoin(IndexedTable([:aapl,:ibm,:msft,:msft],[1,1,1,3],[4,5,6,7]),
+               IndexedTable([:aapl,:ibm,:msft],[0,0,0],[8,9,10])) ==
+                   IndexedTable([:aapl,:ibm,:msft,:msft],[1,1,1,3],[8,9,10,10])
 
 @test aggregate_vec(maximum,
-                    NDSparse([1, 1, 1, 1, 1, 1],
-                             [2, 2, 2, 3, 3, 3],
-                             [1, 4, 3, 5, 2, 0], presorted=true)) ==
-                    NDSparse([1, 1], [2, 3], [4, 5])
+                    IndexedTable([1, 1, 1, 1, 1, 1],
+                                 [2, 2, 2, 3, 3, 3],
+                                 [1, 4, 3, 5, 2, 0], presorted=true)) ==
+                    IndexedTable([1, 1], [2, 3], [4, 5])
 
 @test aggregate_vec([maximum, minimum],
-                    NDSparse([1, 1, 1, 1, 1, 1],
-                             [2, 2, 2, 3, 3, 3],
-                             [1, 4, 3, 5, 2, 0], presorted=true)) ==
-                    NDSparse([1, 1], [2, 3], Columns(maximum=[4, 5], minimum=[1, 0]))
+                    IndexedTable([1, 1, 1, 1, 1, 1],
+                                 [2, 2, 2, 3, 3, 3],
+                                 [1, 4, 3, 5, 2, 0], presorted=true)) ==
+                    IndexedTable([1, 1], [2, 3], Columns(maximum=[4, 5], minimum=[1, 0]))
 
-@test convertdim(NDSparse([1, 1, 1, 1, 1, 1],
-                          [0, 1, 2, 3, 4, 5],
-                          [1, 4, 3, 5, 2, 0], presorted=true), 2, x->div(x,3), vecagg=maximum) ==
-                    NDSparse([1, 1], [0, 1], [4, 5])
+@test convertdim(IndexedTable([1, 1, 1, 1, 1, 1],
+                              [0, 1, 2, 3, 4, 5],
+                              [1, 4, 3, 5, 2, 0], presorted=true), 2, x->div(x,3), vecagg=maximum) ==
+                    IndexedTable([1, 1], [0, 1], [4, 5])
 
 let A = rand(3,3), B = rand(3,3), C = rand(3,3)
-    nA = convert(NDSparse, A)
-    nB = convert(NDSparse, B)
+    nA = convert(IndexedTable, A)
+    nB = convert(IndexedTable, B)
     nB.index.columns[1][:] += 3
-    @test merge(nA,nB) == convert(NDSparse, vcat(A,B))
-    nC = convert(NDSparse, C)
+    @test merge(nA,nB) == convert(IndexedTable, vcat(A,B))
+    nC = convert(IndexedTable, C)
     nC.index.columns[1][:] += 6
-    @test merge(nA,nB,nC) == merge(nA,nC,nB) == convert(NDSparse, vcat(A,B,C))
+    @test merge(nA,nB,nC) == merge(nA,nC,nB) == convert(IndexedTable, vcat(A,B,C))
     merge!(nA,nB)
-    @test nA == convert(NDSparse, vcat(A,B))
+    @test nA == convert(IndexedTable, vcat(A,B))
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,7 +1,7 @@
 using Base.Test
 using IndexedTables
 
-let a = NDSparse([12,21,32], [52,41,34], [11,53,150]), b = NDSparse([12,23,32], [52,43,34], [56,13,10])
+let a = IndexedTable([12,21,32], [52,41,34], [11,53,150]), b = IndexedTable([12,23,32], [52,43,34], [56,13,10])
     p = collect(IndexedTables.product(a, b))
     @test p == [(11,56), (11,13), (11,10), (53,56), (53,13), (53,10), (150,56), (150,13), (150,10)]
 
@@ -29,8 +29,8 @@ end
 
 @test roundtrips(Columns(rand(5), rand(5)))
 @test roundtrips(Columns(c1 = rand(5), c2 = rand(5)))
-@test roundtrips(convert(NDSparse, rand(3,3)))
-@test roundtrips(NDSparse(Columns(y=rand(3), x=rand(3)), rand(3)))
+@test roundtrips(convert(IndexedTable, rand(3,3)))
+@test roundtrips(IndexedTable(Columns(y=rand(3), x=rand(3)), rand(3)))
 
 let x = rand(3), y = rand(3), v = rand(3), w = rand(3)
     @test vcat(Columns(x,y), Columns(v,w)) == Columns(vcat(x,v), vcat(y,w))


### PR DESCRIPTION
Here's a suggested solution to the naming quandary.

- Make `IndexedTable` the canonical name
- a binding deprecation for `NDSparse`
- Provide `Table` as an optional alias. If you're only using IndexedTables, you can do `using IndexedTables.Table` for convenience.
