### PR TITLE
Remove map for NamedTuple

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.5
 Compat 0.19
-NamedTuples
+NamedTuples 2.1.0
 PooledArrays

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,11 +25,6 @@ right(x, y) = y
          Expr(:tuple, [ Expr(:ref, Expr(:., :n, Expr(:quote, fieldname(n,f))), :i) for f = 1:nfields(n) ]...))
 end
 
-@generated function map(f, n::NamedTuple)
-    Expr(:call, Expr(:macrocall, Symbol("@NT"), fieldnames(n)...),
-         [ Expr(:call, :f, Expr(:., :n, Expr(:quote, fieldname(n,f)))) for f = 1:nfields(n) ]...)
-end
-
 @inline foreach(f, a::Tuple) = _foreach(f, a[1], tail(a))
 @inline _foreach(f, x, ra) = (f(x); _foreach(f, ra[1], tail(ra)))
 @inline _foreach(f, x, ra::Tuple{}) = f(x)


### PR DESCRIPTION
This should be the only thing left to do so that the package can be registered (JuliaLang/METADATA.jl#8476).

The REQUIRE bound on ``NamedTuples`` is not ideal, the proper requirement would be ``2.1.0`` if you are on ``2.x``, or ``3.0.2`` if you are on ``3.x``. But I don't think that kind of requirement can be written, so this is probably the best we can do.