### PR TITLE
RFC/WIP: mapslices

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -5,7 +5,7 @@ using NamedTuples, PooledArrays
 
 import Base:
     show, eltype, length, getindex, setindex!, ndims, map, convert,
-    ==, broadcast, empty!, copy, similar, sum, merge, merge!,
+    ==, broadcast, empty!, copy, similar, sum, merge, merge!, mapslices,
     permutedims, reducedim, serialize, deserialize
 
 export IndexedTable, flush!, aggregate!, aggregate_vec, where, pairs, convertdim, columns, column,

--- a/src/query.jl
+++ b/src/query.jl
@@ -284,3 +284,113 @@ function reducedim_vec(f, x::IndexedTable, dims)
 end
 
 reducedim_vec(f, x::IndexedTable, dims::Symbol) = reducedim_vec(f, x, [dims])
+
+function dedup_names(ns)
+    count = Dict{Symbol,Int}()
+    for n in ns
+        if haskey(count, n)
+            count[n] += 1
+        else
+            count[n] = 1
+        end
+    end
+
+    repeated = filter((k,v) -> v > 1, count)
+    for k in keys(repeated)
+        repeated[k] = 0
+    end
+    [haskey(repeated, n) ? Symbol(n, "_", repeated[n]+=1) : n for n in ns]
+end
+
+function mapslices(f, x::IndexedTable, dims; name = nothing)
+    iterdims = setdiff([1:ndims(x);], map(d->fieldindex(x.index.columns,d), dims))
+    idx = Any[Colon() for v in x.index.columns]
+
+    iter = sort(Columns(astuple(x.index.columns)[[iterdims...]]))
+
+    for j in 1:length(iterdims)
+        d = iterdims[j]
+        idx[d] = iter[1][j]
+    end
+    if length(idx) == length(iterdims)
+        idx[end] = vcat(idx[end]) # make last element a vector
+                                  # so that we don't do scalar indexing
+    end
+    y = f(x[idx...]) # Apply on first slice
+
+    if isa(y, IndexedTable)
+        # this means we need to concatenate outputs into a big IndexedTable
+        ns = vcat(dimlabels(x)[iterdims], dimlabels(y))
+        if !all(x->isa(x, Symbol), ns)
+            ns = nothing
+        else
+            ns = dedup_names(ns)
+        end
+        n = length(y)
+        index_first = similar(iter, n)
+        for j=1:n
+            @inbounds index_first[j] = iter[1]
+        end
+        index = Columns(index_first.columns..., astuple(y.index.columns)...; names=ns)
+        data = copy(y.data)
+        output = IndexedTable(index, data)
+        _mapslices_itable!(f, output, x, iter, iterdims, 2)
+    else
+        ns = dimlabels(x)[iterdims]
+        if !all(x->isa(x, Symbol), ns)
+            ns = nothing
+        end
+        index = Columns(iter[1:1].columns...; names=ns)
+        if name === nothing
+            output = IndexedTable(index, [y])
+        else
+            output = IndexedTable(index, Columns([y], names=[name]))
+        end
+        _mapslices_scalar!(f, output, x, iter, iterdims, 2, name!==nothing ? x->(x,) : identity)
+    end
+end
+
+function _mapslices_scalar!(f, output, x, iter, iterdims, start, coerce)
+    idx = Any[Colon() for v in x.index.columns]
+
+    for i = start:length(iter)
+        if i != 1 && roweq(iter, i-1, i) # We've already visited this slice
+            continue
+        end
+        for j in 1:length(iterdims)
+            d = iterdims[j]
+            idx[d] = iter[i][j]
+        end
+        y = f(x[idx...])
+        push!(output.index, iter[i])
+        push!(output.data, coerce(y))
+    end
+    output
+end
+
+function _mapslices_itable!(f, output, x, iter, iterdims, start)
+    idx = Any[Colon() for v in x.index.columns]
+    I = output.index
+    D = output.data
+    initdims = length(iterdims)
+
+    I1 = Columns(I.columns[1:initdims]) # filled from existing table
+    I2 = Columns(I.columns[initdims+1:end]) # filled from output tables
+
+    for i = start:length(iter)
+        if i != 1 && roweq(iter, i-1, i) # We've already visited this slice
+            continue
+        end
+        for j in 1:length(iterdims)
+            d = iterdims[j]
+            idx[d] = iter[i][j]
+        end
+        y = f(x[idx...])
+        n = length(y)
+
+        foreach((x,y)->append_n!(x,y,n), I1.columns, iter[i])
+        append!(I2, y.index)
+        append!(D, y.data)
+    end
+    IndexedTable(I,D)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -254,3 +254,11 @@ function sort_int_range_sub_by!(x, ioffs, n, by, rangelen, minval, temp)
     end
     x
 end
+
+function append_n!(X::Vector, val, n)
+    l = length(X)
+    resize!(X, l+n)
+    for i in (1:n)+l
+        @inbounds X[i] = val
+    end
+end


### PR DESCRIPTION
a first attempt at mapslices:

scalar version (i.e. if map function doesn't return an `IndexedTable`)

```julia
julia> using IndexedTables

julia> x=IndexedTable(Columns(a=[1,1,1,2,2],b=[1,2,3,1,2]),[1,2,3,4,5])
a  b │ 
─────┼──
1  1 │ 1
1  2 │ 2
1  3 │ 3
2  1 │ 4
2  2 │ 5

julia> mapslices(println, x, [1])
a  b │ 
─────┼──
1  1 │ 1
2  1 │ 4
a  b │ 
─────┼──
1  2 │ 2
2  2 │ 5
a  b │ 
─────┼──
1  3 │ 3
b │ 
──┼────────
1 │ nothing
2 │ nothing
3 │ nothing

julia> mapslices(println, x, [:b])
a  b │ 
─────┼──
1  1 │ 1
1  2 │ 2
1  3 │ 3
a  b │ 
─────┼──
2  1 │ 4
2  2 │ 5
a │ 
──┼────────
1 │ nothing
2 │ nothing
```
non-scalar version (i.e. function returns an IndexedTable):
```julia
julia> r=Ref(0);

julia> mapslices(x, [:a]) do slice
           println("input:")
           println(slice)
           r[] += 1
           n = length(slice)
           output = IndexedTable(Columns(c=[1:n;]), [r[] for i=1:n])
           println("output:")
           println(output)
           output
       end
input:
a  b │ 
─────┼──
1  1 │ 1
2  1 │ 4
output:
c │ 
──┼──
1 │ 1
2 │ 1
input:
a  b │ 
─────┼──
1  1 │ 1
2  1 │ 4
output:
c │ 
──┼──
1 │ 2
2 │ 2
input:
a  b │ 
─────┼──
1  2 │ 2
2  2 │ 5
output:
c │ 
──┼──
1 │ 3
2 │ 3
input:
a  b │ 
─────┼──
1  3 │ 3
output:
c │ 
──┼──
1 │ 4
b  c │ 
─────┼──
1  1 │ 1
1  1 │ 2
1  2 │ 1
1  2 │ 2
2  1 │ 3
2  2 │ 3
3  1 │ 4

julia> r=Ref(0);

julia> mapslices(x, [:b]) do slice
           println("input:")
           println(slice)
           r[] += 1
           n = length(slice)
           output = IndexedTable(Columns(c=[1:n;]), [r[] for i=1:n])
           println("output:")
           println(output)
           output
       end
input:
a  b │ 
─────┼──
1  1 │ 1
1  2 │ 2
1  3 │ 3
output:
c │ 
──┼──
1 │ 1
2 │ 1
3 │ 1
input:
a  b │ 
─────┼──
1  1 │ 1
1  2 │ 2
1  3 │ 3
output:
c │ 
──┼──
1 │ 2
2 │ 2
3 │ 2
input:
a  b │ 
─────┼──
2  1 │ 4
2  2 │ 5
output:
c │ 
──┼──
1 │ 3
2 │ 3
a  c │ 
─────┼──
1  1 │ 1
1  1 │ 2
1  2 │ 1
1  2 │ 2
1  3 │ 1
1  3 │ 2
2  1 │ 3
2  2 │ 3
```

basically dimensions of the returned slices are tacked on to the end of the remaining indices of the table.

Some questions:

- what should we do if some dimensions returned from the mapping function are common to the remaining dimensions? Right now they get a new name: `a` becomes `a_1` and the rest is handled similarly
- should we drop the sliced dimension in the input? It seems useful, but may be redundant.
- should this function take an aggregate function as well?

```
julia> mapslices(x->rand(), rand(2,2), 1)
1×2 Array{Float64,2}:
 0.302282  0.403092

julia> mapslices(x->rand(2), rand(2,2), 1)
2×2 Array{Float64,2}:
 0.759656  0.0750492
 0.801441  0.273785 

julia> mapslices(x->rand(2,2), rand(2,2), 1)
ERROR: DimensionMismatch("tried to assign 2 elements to 1 destinations")
```

what's the equivalent of this??

cc @simonbyrne 