### PR TITLE
make `pick` more useful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 julia:
   - 0.5
-  - nightly
+  - 0.6
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.5 0.7-
 Compat 0.19
 NamedTuples 2.1.0
 PooledArrays

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -122,8 +122,8 @@ end
 sort!(c::Columns) = permute!(c, sortperm(c))
 sort(c::Columns) = c[sortperm(c)]
 
+map(p::ProjFn, c::Columns) = Columns(p(c.columns))
 map(p::Proj, c::Columns) = p(c.columns)
-(p::Proj)(c::Columns) = p(c.columns)
 
 vcat{D<:Tup,C<:Tuple}(c::Columns{D,C}, cs::Columns{D,C}...) = Columns{D,C}((map(vcat, map(x->x.columns, (c,cs...))...)...,))
 vcat{D<:Tup,C<:NamedTuple}(c::Columns{D,C}, cs::Columns{D,C}...) = Columns{D,C}(C(map(vcat, map(x->x.columns, (c,cs...))...)...,))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -98,7 +98,10 @@ macro pick(ex...)
     tup = if all([isa(x, Symbol) for x in ex])
         # Named tuple
         args = [:(getfield(x, $(Expr(:quote, f)))) for f in ex]
-        Expr(:macrocall, :(NamedTuples.$(Symbol("@NT"))), map((x,y) -> :($x=$y), map(esc, ex), args)...)
+        T = Expr(:macrocall,
+                 :(NamedTuples.$(Symbol("@NT"))),
+                   map((x) -> :($(esc(x))), ex)...)
+        :($T($(args...)))
     else
         :(($([:(getfield(x, $f)) for f in ex]...),))
     end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -1,6 +1,7 @@
 using Base.Test
 using IndexedTables
 using PooledArrays
+using NamedTuples
 
 let a = Columns([1,2,1],["foo","bar","baz"]),
     b = Columns([2,1,1],["bar","baz","foo"]),
@@ -22,11 +23,26 @@ let c = Columns([1,1,1,2,2], [1,2,4,3,5]),
     f = Columns([1,1,1], sort([rand(),0.5,rand()]))
     @test merge(IndexedTable(c,ones(5)),IndexedTable(d,ones(5))).index == Columns([1,1,1,1,2,2,2,2],[1,2,3,4,1,3,4,5])
     @test eltype(merge(IndexedTable(c,Columns(ones(Int, 5))),IndexedTable(d,Columns(ones(Float64, 5)))).data) == Tuple{Float64}
-    @test eltype(merge(IndexedTable(c,Columns(x=ones(Int, 5))),IndexedTable(d,Columns(x=ones(Float64, 5)))).data) == NamedTuples.@NT(x){Float64}
+    @test eltype(merge(IndexedTable(c,Columns(x=ones(Int, 5))),IndexedTable(d,Columns(x=ones(Float64, 5)))).data) == @NT(x){Float64}
     @test length(merge(IndexedTable(e,ones(3)),IndexedTable(f,ones(3)))) == 5
     @test vcat(Columns(x=[1]), Columns(x=[1.0])) == Columns(x=[1,1.0])
     @test vcat(Columns(x=PooledArray(["x"])), Columns(x=["y"])) == Columns(x=["x", "y"])
+
     @test summary(c) == "Columns{Tuple{Int64,Int64}}"
+end
+
+let
+    x = Columns([1], [2.0])
+    @test map(pick(2), x) == [2.0]
+    @test map(@pick(2), x) == Columns([2.0])
+    @test map(@pick(2,1), x) == Columns([2.0], [1])
+
+    y = Columns(x=[1], y=[2.0])
+    @test map(pick(2), y) == [2.0]
+    @test map(@pick(2), y) == Columns([2.0])
+    @test map(@pick(y), y) == Columns(y=[2.0])
+    @test map(@pick(2,1), y) == Columns([2.0], [1])
+    @test map(@pick(y,x), y) == Columns(y=[2.0], x=[1])
 end
 
 let c = Columns([1,1,1,2,2], [1,2,4,3,5]),


### PR DESCRIPTION
```julia
julia> c = Columns(x=[1,2],y=[2.,4])
2-element IndexedTables.Columns{NamedTuples._NT_x_y{Int64,Float64},NamedTuples._NT_x_y{Array{Int64,1},Array{Float64,1}}}:
 (x = 1, y = 2.0)
 (x = 2, y = 4.0)
julia> pick(:y)(c)
2-element Array{Float64,1}:
 2.0
 4.0

julia> pick(:y)(c)
2-element Array{Float64,1}:
 2.0
 4.0

julia> pick((:y,))(c)
2-element IndexedTables.Columns{NamedTuples._NT_y{Float64},NamedTuples._NT_y{Array{Float64,1}}}:
 (y = 2.0)
 (y = 4.0)

julia> pick((:y,:x))(c)
2-element IndexedTables.Columns{NamedTuples._NT_y_x{Float64,Int64},NamedTuples._NT_y_x{Array{Float64,1},Array{Int64,1}}}:
 (y = 2.0, x = 1)
 (y = 4.0, x = 2)

julia> pick((2,1))(c)
2-element IndexedTables.Columns{NamedTuples._NT_y_x{Float64,Int64},NamedTuples._NT_y_x{Array{Float64,1},Array{Int64,1}}}:
 (y = 2.0, x = 1)
 (y = 4.0, x = 2)
```

The multiple column version is not inferable in the case the columns are of different types. That can be fixed by using `Base.@pure` if required.