### PR TITLE
RFC: keep index column names in convertdim by default

### DIFF
--- a/src/query.jl
+++ b/src/query.jl
@@ -230,9 +230,11 @@ function convertdim(x::IndexedTable, d::DimName, xlat; agg=nothing, vecagg=nothi
     d2 = map(xlat, cols[d])
     n = fieldindex(cols, d)
     names = nothing
-    if isa(x.index.columns, NamedTuple) && name !== nothing
+    if isa(x.index.columns, NamedTuple)
         names = fieldnames(x.index.columns)
-        names[n] = name
+        if name !== nothing
+            names[n] = name
+        end
     end
     if vecagg !== nothing
         y = IndexedTable(cols[1:n-1]..., d2, cols[n+1:end]..., x.data, copy=false, names=names)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -188,7 +188,7 @@ let x = IndexedTable(Columns(x = [1,2,3], y = [4,5,6], z = [7,8,9]), [10,11,12])
     @test _colnames(select(x, :y)) == [:y]
     @test _colnames(select(x, :x=>a->a>1, :z=>a->a>7)) == names
     @test _colnames(x[1:2, 4:5, 8:9]) == names
-    @test convertdim(x, :y, a->0) == IndexedTable(Columns([1,2,3], [0,0,0], [7,8,9]), [10,11,12])
+    @test convertdim(x, :y, a->0) == IndexedTable(Columns(x=[1,2,3], y=[0,0,0], z=[7,8,9]), [10,11,12])
     @test convertdim(x, :y, a->0, name=:yy) == IndexedTable(Columns(x=[1,2,3], yy=[0,0,0], z=[7,8,9]), [10,11,12])
 end
 


### PR DESCRIPTION
Right now the index columns become nameless after a `convertdim` if no name for the converted column is specified. I think keeping the names would be more useful, and might prompt users to look up "a way to change name of converted column" rather than prompt them to assume `convertdim` just loses the names.

The documentation says `name optionally specifies a new
  name for the translated dimension.` and nothing about the behavior if it's omitted.