### PR TITLE
similar(::Columns) should return a Columns of the same size

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -77,7 +77,7 @@ function IndexedTable(columns...; names=nothing, rest...)
     IndexedTable(Columns(keys..., names=names), data; rest...)
 end
 
-similar(t::IndexedTable) = IndexedTable(similar(t.index), empty!(similar(t.data)))
+similar(t::IndexedTable) = IndexedTable(similar(t.index, 0), similar(t.data, 0))
 
 function copy(t::IndexedTable)
     flush!(t)

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -44,7 +44,7 @@ size(c::Columns) = (length(c),)
 summary{D<:Tuple}(c::Columns{D}) = "Columns{$D}"
 
 empty!(c::Columns) = (foreach(empty!, c.columns); c)
-similar{D,C}(c::Columns{D,C}) = empty!(Columns{D,C}(map(similar, c.columns)))
+similar{D,C}(c::Columns{D,C}) = Columns{D,C}(map(similar, c.columns))
 similar{D,C}(c::Columns{D,C}, n::Integer) = Columns{D,C}(map(a->similar(a,n), c.columns))
 copy{D,C}(c::Columns{D,C}) = Columns{D,C}(map(copy, c.columns))
 

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -14,6 +14,7 @@ let a = Columns([1,2,1],["foo","bar","baz"]),
     @test a == b == c
     @test size(a) == size(b) == size(c) == (3,)
     @test eltype(a) == Tuple{Int,String}
+    @test length(similar(a)) == 3
 end
 
 let c = Columns([1,1,1,2,2], [1,2,4,3,5]),


### PR DESCRIPTION
This was breaking [this line](https://github.com/JuliaComputing/IndexedTables.jl/blob/master/src/join.jl#L132) because the call to similar above doesn't specify a length.