### PR TITLE
use IntervalSets for indexing

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.5 0.7-
 Compat 0.19
 NamedTuples 2.1.0
 PooledArrays
+IntervalSets

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -138,6 +138,10 @@ let a = IndexedTable([1,2,2,2], [1,2,3,4], [10,9,8,7])
     #@test_throws ErrorException a[2]
     @test a[2,:] == IndexedTable([2,2,2], [2,3,4], [9,8,7])
     @test a[:,1] == IndexedTable([1], [1], [10])
+    @test a[:,:] == a
+    @test a[2..2,2..3] == IndexedTable([2,2], [2,3], [9,8])
+    @test a[2,2..3] == IndexedTable([2,2], [2,3], [9,8])
+    @test a[2..2,:] == IndexedTable([2,2,2], [2,3,4], [9,8,7])
     @test collect(where(a, 2, :)) == [9,8,7]
     @test collect(pairs(a)) == [(1,1)=>10, (2,2)=>9, (2,3)=>8, (2,4)=>7]
     @test first(pairs(a, :, 3)) == ((2,3)=>8)


### PR DESCRIPTION
There are two optimizations here:

1) define `_in` for `Range` which was getting caught by `_in(::AbstractVector)` method and doing a slow lookup
2) Try to omit unnecessary columns (for which `_in` will always be true) in the second-pass check to see if indices fall inside the specified query.

Also, we now reexport `..` from IntervalSets which makes for a really nice indexing experience for Dates (you don't have to mention timestep of 1 millisecond, you can even give a Date range for a DateTime column and it will be closed range which includes the whole 2 days!). In general indexing with ClosedInterval is also faster than with ranges.