### PR TITLE
Fix performance of IndexedTable constructor

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -46,7 +46,7 @@ function IndexedTable{T,D,C}(I::Columns{D,C}, d::AbstractVector{T}; agg=nothing,
     # ensure index is a `Columns` that generates tuples
     dt = D
     if eltype(I) <: NamedTuple
-        dt = eltypes(typeof((I.columns...,)))
+        dt = astuple(eltype(I))
         I = Columns{dt,C}(I.columns)
     end
     if !presorted && !issorted(I)

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -33,8 +33,7 @@ end
 
 Columns(; pairs...) = Columns(map(x->x[2],pairs)..., names=Symbol[x[1] for x in pairs])
 
-Columns(c::Tuple) = Columns{eltypes(typeof(c)),typeof(c)}(c)
-Columns(c::NamedTuple) = Columns(c..., names=fieldnames(c))
+Columns(c::Tup) = Columns{eltypes(typeof(c)),typeof(c)}(c)
 
 eltype{D,C}(::Type{Columns{D,C}}) = D
 length(c::Columns) = length(c.columns[1])

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -18,6 +18,14 @@ let a = Columns([1,2,1],["foo","bar","baz"]),
     @test length(similar(a)) == 3
 end
 
+let
+    @inferred Columns(@NT(c=[1]))
+    @inferred Columns([1])
+    @test_throws ErrorException @inferred Columns(c=[1]) # bad
+    @inferred IndexedTable(Columns(c=[1]), [1])
+    @inferred IndexedTable(Columns([1]), [1])
+end
+
 let c = Columns([1,1,1,2,2], [1,2,4,3,5]),
     d = Columns([1,1,2,2,2], [1,3,1,4,5]),
     e = Columns([1,1,1], sort([rand(),0.5,rand()])),


### PR DESCRIPTION
When constructing Columns with NamedTuples

before

```julia
julia> @btime IndexedTable(Columns(@NT(c=[1,2,3])), [1,3,2])
  78.806 μs (113 allocations: 5.63 KiB)
```
after
```julia
julia> @btime IndexedTable(Columns(@NT(c=[1,2,3])), [1,3,2])
  287.561 ns (14 allocations: 672 bytes)
```