### PR TITLE
Don't force index Columns eltype to be Tuple

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -6,7 +6,7 @@ _getindex{T,D<:Tuple}(t::IndexedTable{T,D}, idxs::D) = _getindex_scalar(t, idxs)
 _getindex(t::IndexedTable, idxs::Tuple{Vararg{Real}}) = _getindex_scalar(t, idxs)
 
 function _getindex_scalar(t, idxs)
-    i = searchsorted(t.index, idxs)
+    i = searchsorted(t.index, convertkey(t, idxs))
     length(i) != 1 && throw(KeyError(idxs))
     t.data[first(i)]
 end
@@ -54,7 +54,7 @@ end
 function _getindex(t::IndexedTable, idxs)
     I = t.index
     cs = astuple(I.columns)
-    if length(idxs) != length(I.columns)
+    if nfields(idxs) !== nfields(I.columns)
         error("wrong number of indices")
     end
     for idx in idxs

--- a/src/query.jl
+++ b/src/query.jl
@@ -315,10 +315,8 @@ function mapslices(f, x::IndexedTable, dims; name = nothing)
         d = iterdims[j]
         idx[d] = iter[1][j]
     end
-    T = eltypes(typeof(x.index.columns))
-    wrap = T<:Tuple ? tuple : T
     if isempty(dims)
-        y = f(T(first(x.index)...) => first(x.data))
+        y = f(first(x.index) => first(x.data))
     else
         y = f(x[idx...]) # Apply on first slice
     end
@@ -340,7 +338,7 @@ function mapslices(f, x::IndexedTable, dims; name = nothing)
         data = copy(y.data)
         output = IndexedTable(index, data)
         if isempty(dims)
-            _mapslices_itable_singleton!(f, output, x, wrap, 2)
+            _mapslices_itable_singleton!(f, output, x, 2)
         else
             _mapslices_itable!(f, output, x, iter, iterdims, 2)
         end
@@ -384,7 +382,7 @@ function _mapslices_scalar!(f, output, x, iter, iterdims, start, coerce)
     output
 end
 
-function _mapslices_itable_singleton!(f, output, x, wrap, start)
+function _mapslices_itable_singleton!(f, output, x, start)
     I = output.index
     D = output.data
 
@@ -393,7 +391,7 @@ function _mapslices_itable_singleton!(f, output, x, wrap, start)
     i = 1
     for (k, v) in zip(x.index[start:end], x.data[start:end])
         i+=1
-        y = f(wrap(k...)=>v)
+        y = f(k=>v)
         n = length(y)
 
         foreach((x,y)->append_n!(x,y,n), I1.columns, k)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,6 +9,7 @@ eltypes{T<:Tuple}(::Type{T}) =
     tuple_type_cons(eltype(tuple_type_head(T)), eltypes(tuple_type_tail(T)))
 eltypes{T<:NamedTuple}(::Type{T}) = map_params(eltype, T)
 Base.@pure astuple{T<:NamedTuple}(::Type{T}) = Tuple{T.parameters...}
+astuple{T<:Tuple}(::Type{T}) = T
 
 # sizehint, making sure to return first argument
 _sizehint!{T}(a::Array{T,1}, n::Integer) = (sizehint!(a, n); a)


### PR DESCRIPTION
Scalar indexing now converts the tuple to NamedTuple and does the lookup.