### PR TITLE
WIP/RFC: Iteration API

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -215,6 +215,12 @@ identified by `which`.
 """
 rows(t::IndexedTable, which...) = rows(columns(t, which...))
 rows(t::Columns, which...) = rows(columns(t, which...))
+function rows(t::AbstractVector, which...)
+    if all(x->x==1, which)
+        Columns(map(x->t, which))
+    else error("No column $(join(filter(x->x!=1, which), " "))")
+    end
+end
 
 ## Row-wise iteration that acknowledges key-value nature
 
@@ -236,7 +242,7 @@ keys(t::IndexedTable, which...) = rows(keys(t), which...)
 """
 `values(t)`
 
-Returns an array of values stored `t`.
+Returns an array of values stored in `t`.
 """
 values(t::IndexedTable) = t.data
 
@@ -247,13 +253,6 @@ Returns a array of rows from a subset of columns
 of the values in `t`.
 """
 values(t::IndexedTable, which...) = rows(values(t), which...)
-
-"""
-`pairs(t)`
-
-Returns an array of key-value pairs in `t`
-"""
-pairs(t::IndexedTable) = Columns(keys(t), values(t))
 
 ## As
 

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -122,6 +122,14 @@ or at the given index (which::Int).
     getfield(c.columns, x)
 end
 
+function column(c::AbstractVector, x::Union{Int, Symbol})
+    if x == 1
+        return c
+    else
+        error("No column $x")
+    end
+end
+
 has_column(t::Columns, c::Int) = c <= nfields(columns(t))
 has_column(t::Columns, c::Symbol) = isa(columns(t), NamedTuple) ? haskey(columns(t), c) : false
 
@@ -198,7 +206,7 @@ Use `as(src, dest)` as the argument to rename a column
 from `src` to `dest`. Optionally, you can specify a
 function `f` to apply to the column: `as(f, src, dest)`.
 """
-function columns(c::Union{Columns, IndexedTable}, which...)
+function columns(c::Union{AbstractVector, IndexedTable}, which...)
     tupletype = _output_tuple(which)
     tupletype((column(c, w) for w in which)...)
 end
@@ -221,13 +229,7 @@ Returns an array of rows in a subset of columns in `t`
 identified by `which`.
 """
 rows(t::IndexedTable, which...) = rows(columns(t, which...))
-rows(t::Columns, which...) = rows(columns(t, which...))
-function rows(t::AbstractVector, which...)
-    if all(x->x==1, which)
-        Columns(map(x->t, which))
-    else error("No column $(join(filter(x->x!=1, which), " "))")
-    end
-end
+rows(t::AbstractVector, which...) = rows(columns(t, which...))
 
 ## Row-wise iteration that acknowledges key-value nature
 
@@ -273,7 +275,7 @@ as(f, src, dest) = As(f, src, dest)
 as(src, dest) = as(identity, src, dest)
 
 _name(x::As) = x.dest
-function column(t::Union{IndexedTable, Columns}, a::As)
+function column(t::Union{IndexedTable, AbstractVector}, a::As)
     a.f(column(t, a.src))
 end
 

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -4,11 +4,11 @@ using Compat
 using NamedTuples, PooledArrays
 
 import Base:
-    show, eltype, length, getindex, setindex!, ndims, map, convert,
+    show, eltype, length, getindex, setindex!, ndims, map, convert, keys, values,
     ==, broadcast, empty!, copy, similar, sum, merge, merge!, mapslices,
     permutedims, reducedim, serialize, deserialize
 
-export IndexedTable, flush!, aggregate!, aggregate_vec, where, pairs, convertdim, columns, column,
+export IndexedTable, flush!, aggregate!, aggregate_vec, where, pairs, convertdim, columns, column, rows, as,
     update!, aggregate, reducedim_vec, dimlabels
 
 const Tup = Union{Tuple,NamedTuple}
@@ -100,6 +100,176 @@ ndims(t::IndexedTable) = length(t.index.columns)
 length(t::IndexedTable) = (flush!(t);length(t.index))
 eltype{T,D,C,V}(::Type{IndexedTable{T,D,C,V}}) = T
 dimlabels{T,D,C,V}(::Type{IndexedTable{T,D,C,V}}) = fieldnames(eltype(C))
+
+### Iteration API
+
+## Extracting a single column
+
+"""
+`column(c::Columns, which)`
+
+Returns the column with a given name (which::Symbol)
+or at the given index (which::Int).
+"""
+@inline function column(c::Columns, x::Union{Int, Symbol})
+    getfield(c.columns, x)
+end
+
+has_column(t::Columns, c::Int) = c <= nfields(columns(t))
+has_column(t::Columns, c::Symbol) = isa(columns(t), NamedTuple) ? haskey(columns(t), c) : false
+
+"""
+`column(t::IndexedTable, which)`
+
+Returns a single column from `t`. `which` can be:
+
+- `Symbol`: returns the column with the given name.
+  If the same name appears in keys and values,
+  the keys column is returned.
+- `Int`: returns the column with the given number.
+  Numbering begins from index columns and then continues
+  to value columns.
+"""
+function column(t::IndexedTable, n::Int)
+    if has_column(keys(t), n)
+        return column(keys(t), n)
+    end
+
+    n = n - length(keys(t).columns)
+    if isa(values(t), Columns) && has_column(values(t), n)
+        return column(values(t), n)
+    elseif n == 1
+        return values(t)
+    end
+
+    error("Couldn't find column numbered $n")
+end
+
+function column(t::IndexedTable, col::Symbol)
+    if has_column(keys(t), col)
+        return column(keys(t), col)
+    end
+
+    if has_column(values(t), col)
+        return column(values(t), col)
+    end
+
+    error("Couldn't find column named $n")
+end
+
+## Column-wise iteration:
+
+columns(v::AbstractVector) = (v,)
+columns(c::Columns) = c.columns
+
+"""
+`columns(t::IndexedTable)`
+
+Returns a tuple or named tuple of column vectors.
+It requires key and value columns to have unique names.
+"""
+columns(t::IndexedTable) = concat_tup(columns(keys(t)),
+                                      columns(values(t)))
+
+_name(x::Union{Int, Symbol}) = x
+function _output_tuple(which::Tuple)
+    names = map(_name, which)
+    if all(x->isa(x, Symbol), names)
+        return namedtuple(names...)
+    else
+        return tuple
+    end
+end
+
+"""
+`columns(t::IndexedTable, which...)`
+
+Returns a subset of columns identified by `which`
+as a tuple or named tuple of vectors.
+
+Use `as(src, dest)` as the argument to rename a column
+from `src` to `dest`. Optionally, you can specify a
+function `f` to apply to the column: `as(f, src, dest)`.
+"""
+function columns(c::Union{Columns, IndexedTable}, which...)
+    tupletype = _output_tuple(which)
+    tupletype((column(c, w) for w in which)...)
+end
+
+## Row-wise iteration
+
+"""
+`rows(t)`
+
+Returns an array of rows in the table `t`. Keys and values
+are merged into a contiguous tuple / named tuple.
+"""
+rows(x::AbstractVector) = x
+rows(cols::Tup) = Columns(cols)
+
+"""
+`rows(t, which...)`
+
+Returns an array of rows in a subset of columns in `t`
+identified by `which`.
+"""
+rows(t::IndexedTable, which...) = rows(columns(t, which...))
+rows(t::Columns, which...) = rows(columns(t, which...))
+
+## Row-wise iteration that acknowledges key-value nature
+
+"""
+`keys(t::IndexedTable)`
+
+Returns an array of the keys in `t` as tuples or named tuples.
+"""
+keys(t::IndexedTable) = t.index
+
+"""
+`keys(t, which...)`
+
+Returns a array of rows from a subset of columns
+in the index of `t`.
+"""
+keys(t::IndexedTable, which...) = rows(keys(t), which...)
+
+"""
+`values(t)`
+
+Returns an array of values stored `t`.
+"""
+values(t::IndexedTable) = t.data
+
+"""
+`values(t, which...)`
+
+Returns a array of rows from a subset of columns
+of the values in `t`.
+"""
+values(t::IndexedTable, which...) = rows(values(t), which...)
+
+"""
+`pairs(t)`
+
+Returns an array of key-value pairs in `t`
+"""
+pairs(t::IndexedTable) = Columns(keys(t), values(t))
+
+## As
+
+struct As{F}
+    f::F
+    src::Union{Int, Symbol}
+    dest::Union{Int, Symbol}
+end
+
+as(f, src, dest) = As(f, src, dest)
+as(src, dest) = as(identity, src, dest)
+
+_name(x::As) = x.dest
+function column(t::Union{IndexedTable, Columns}, a::As)
+    a.f(column(t, a.src))
+end
 
 """
 `dimlabels(t::IndexedTable)`
@@ -212,17 +382,17 @@ map{T,D<:Tuple,C<:Tup,V<:Columns}(p::Proj, x::IndexedTable{T,D,C,V}) =
 
 (p::Proj)(x::IndexedTable) = map(p, x)
 
-"""
-`columns(x::IndexedTable, names...)`
+# """
+# `columns(x::IndexedTable, names...)`
+#
+# Given an IndexedTable array with multiple data columns (its data vector is a `Columns` object), return a
+# new array with the specified subset of data columns. Data is shared with the original array.
+# """
+# columns(x::IndexedTable, which...) = IndexedTable(x.index, Columns(x.data.columns[[which...]]), presorted=true)
 
-Given an IndexedTable array with multiple data columns (its data vector is a `Columns` object), return a
-new array with the specified subset of data columns. Data is shared with the original array.
-"""
-columns(x::IndexedTable, which...) = IndexedTable(x.index, Columns(x.data.columns[[which...]]), presorted=true)
+#columns(x::IndexedTable, which) = IndexedTable(x.index, x.data.columns[which], presorted=true)
 
-columns(x::IndexedTable, which) = IndexedTable(x.index, x.data.columns[which], presorted=true)
-
-column(x::IndexedTable, which) = columns(x, which)
+#column(x::IndexedTable, which) = columns(x, which)
 
 # IndexedTable uses lex order, Base arrays use colex order, so we need to
 # reorder the data. transpose and permutedims are used for this.

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -9,7 +9,7 @@ import Base:
     permutedims, reducedim, serialize, deserialize
 
 export IndexedTable, flush!, aggregate!, aggregate_vec, where, pairs, convertdim, columns, column, rows, as,
-    update!, aggregate, reducedim_vec, dimlabels
+    itable, update!, aggregate, reducedim_vec, dimlabels
 
 const Tup = Union{Tuple,NamedTuple}
 const DimName = Union{Int,Symbol}
@@ -100,6 +100,13 @@ ndims(t::IndexedTable) = length(t.index.columns)
 length(t::IndexedTable) = (flush!(t);length(t.index))
 eltype{T,D,C,V}(::Type{IndexedTable{T,D,C,V}}) = T
 dimlabels{T,D,C,V}(::Type{IndexedTable{T,D,C,V}}) = fieldnames(eltype(C))
+
+itable(keycols::Columns, valuecols::AbstractVector) =
+    IndexedTable(keycols, valuecols)
+
+function itable(keycols::Tup, valuecols::Tup)
+    IndexedTable(Columns(keycols), Columns(valuecols))
+end
 
 ### Iteration API
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -100,7 +100,7 @@ function update!{N}(f::Union{Function,Type}, d::IndexedTable, idxs::Vararg{Any,N
     d
 end
 
-#pairs(d::IndexedTable) = (d.index[i]=>d.data[i] for i in 1:length(d))
+pairs(d::IndexedTable) = (d.index[i]=>d.data[i] for i in 1:length(d))
 
 """
 `pairs(arr::IndexedTable, indices...)`

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -6,7 +6,7 @@ _getindex{T,D<:Tuple}(t::IndexedTable{T,D}, idxs::D) = _getindex_scalar(t, idxs)
 _getindex(t::IndexedTable, idxs::Tuple{Vararg{Real}}) = _getindex_scalar(t, idxs)
 
 function _getindex_scalar(t, idxs)
-    i = searchsorted(t.index, idxs)
+    i = searchsorted(t.index, convertkey(t, idxs))
     length(i) != 1 && throw(KeyError(idxs))
     t.data[first(i)]
 end
@@ -54,7 +54,7 @@ end
 function _getindex(t::IndexedTable, idxs)
     I = t.index
     cs = astuple(I.columns)
-    if length(idxs) != length(I.columns)
+    if nfields(idxs) !== nfields(I.columns)
         error("wrong number of indices")
     end
     for idx in idxs

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -100,7 +100,7 @@ function update!{N}(f::Union{Function,Type}, d::IndexedTable, idxs::Vararg{Any,N
     d
 end
 
-pairs(d::IndexedTable) = (d.index[i]=>d.data[i] for i in 1:length(d))
+#pairs(d::IndexedTable) = (d.index[i]=>d.data[i] for i in 1:length(d))
 
 """
 `pairs(arr::IndexedTable, indices...)`

--- a/src/query.jl
+++ b/src/query.jl
@@ -315,10 +315,8 @@ function mapslices(f, x::IndexedTable, dims; name = nothing)
         d = iterdims[j]
         idx[d] = iter[1][j]
     end
-    T = eltypes(typeof(x.index.columns))
-    wrap = T<:Tuple ? tuple : T
     if isempty(dims)
-        y = f(T(first(x.index)...) => first(x.data))
+        y = f(first(x.index) => first(x.data))
     else
         y = f(x[idx...]) # Apply on first slice
     end
@@ -340,7 +338,7 @@ function mapslices(f, x::IndexedTable, dims; name = nothing)
         data = copy(y.data)
         output = IndexedTable(index, data)
         if isempty(dims)
-            _mapslices_itable_singleton!(f, output, x, wrap, 2)
+            _mapslices_itable_singleton!(f, output, x, 2)
         else
             _mapslices_itable!(f, output, x, iter, iterdims, 2)
         end
@@ -384,7 +382,7 @@ function _mapslices_scalar!(f, output, x, iter, iterdims, start, coerce)
     output
 end
 
-function _mapslices_itable_singleton!(f, output, x, wrap, start)
+function _mapslices_itable_singleton!(f, output, x, start)
     I = output.index
     D = output.data
 
@@ -393,7 +391,7 @@ function _mapslices_itable_singleton!(f, output, x, wrap, start)
     i = 1
     for (k, v) in zip(x.index[start:end], x.data[start:end])
         i+=1
-        y = f(wrap(k...)=>v)
+        y = f(k=>v)
         n = length(y)
 
         foreach((x,y)->append_n!(x,y,n), I1.columns, k)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,6 +9,7 @@ eltypes{T<:Tuple}(::Type{T}) =
     tuple_type_cons(eltype(tuple_type_head(T)), eltypes(tuple_type_tail(T)))
 eltypes{T<:NamedTuple}(::Type{T}) = map_params(eltype, T)
 Base.@pure astuple{T<:NamedTuple}(::Type{T}) = Tuple{T.parameters...}
+astuple{T<:Tuple}(::Type{T}) = T
 
 # sizehint, making sure to return first argument
 _sizehint!{T}(a::Array{T,1}, n::Integer) = (sizehint!(a, n); a)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -26,6 +26,39 @@ let
     @inferred IndexedTable(Columns([1]), [1])
 end
 
+let
+    x = IndexedTable(Columns(a=[1,1], b=[1,2]), Columns(c=[3,4]))
+    y = IndexedTable(Columns(a=[1,1], b=[1,2]), [3,4])
+
+    @test column(x, :a) == [1,1]
+    @test column(x, :b) == [1,2]
+    @test column(x, :c) == [3,4]
+    @test column(x, 3) == [3,4]
+    @test column(y, 3) == [3,4]
+
+    @test columns(x, :a) == @NT(a=[1,1])
+    @test columns(x, :a,:c) == @NT(a=[1,1], c=[3,4])
+    @test columns(y, 1, 3) == ([1,1], [3,4])
+
+    @test rows(x) == [@NT(a=1,b=1,c=3), @NT(a=1,b=2,c=4)]
+    @test rows(x, :b) == [@NT(b=1), @NT(b=2)]
+    @test rows(x, :b, :c) == [@NT(b=1,c=3), @NT(b=2,c=4)]
+
+    @test keys(x) == [@NT(a=1,b=1), @NT(a=1,b=2)]
+    @test keys(x, :a) == [@NT(a=1), @NT(a=1)]
+    @test keys(x, :a, :b, 2) == [(1,1,1), (1,2,2)]
+
+    @test keys(x, :a, :b, 2) == [(1,1,1), (1,2,2)]
+    @test values(x) == [@NT(c=3), @NT(c=4)]
+    @test values(x,1) == [(3,),(4,)]
+    @test values(x,1,1) == [(3,3), (4,4)]
+    @test values(y) == [3, 4]
+    @test values(y,1) == [(3,),(4,)]
+
+    @test collect(pairs(x)) == [@NT(a=1,b=1)=>@NT(c=3), @NT(a=1,b=2)=>@NT(c=4)]
+    @test collect(pairs(y)) == [@NT(a=1,b=1)=>3, @NT(a=1,b=2)=>4]
+end
+
 let c = Columns([1,1,1,2,2], [1,2,4,3,5]),
     d = Columns([1,1,2,2,2], [1,3,1,4,5]),
     e = Columns([1,1,1], sort([rand(),0.5,rand()])),

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -43,6 +43,7 @@ let
     @test rows(x) == [@NT(a=1,b=1,c=3), @NT(a=1,b=2,c=4)]
     @test rows(x, :b) == [@NT(b=1), @NT(b=2)]
     @test rows(x, :b, :c) == [@NT(b=1,c=3), @NT(b=2,c=4)]
+    @test rows(x,:c, as(-, :b, :x)) == [@NT(c=3, x=-1),@NT(c=4, x=-2)]
 
     @test keys(x) == [@NT(a=1,b=1), @NT(a=1,b=2)]
     @test keys(x, :a) == [@NT(a=1), @NT(a=1)]
@@ -54,6 +55,7 @@ let
     @test values(x,1,1) == [(3,3), (4,4)]
     @test values(y) == [3, 4]
     @test values(y,1) == [(3,),(4,)]
+    @test values(y,as(1, :x)) == [@NT(x=3),@NT(x=4)]
 
     @test collect(pairs(x)) == [@NT(a=1,b=1)=>@NT(c=3), @NT(a=1,b=2)=>@NT(c=4)]
     @test collect(pairs(y)) == [@NT(a=1,b=1)=>3, @NT(a=1,b=2)=>4]

--- a/test/test_query.jl
+++ b/test/test_query.jl
@@ -112,17 +112,12 @@ let
     @test t==IndexedTable(Columns(a_1=[1], a_2=[2], c=[2]), Columns(d=[1]))
 
     # signleton slices
-    x=IndexedTable(Columns(a=[1,2,3,4]),Columns(b=[1,2,3,4]))
-    t = mapslices(x,()) do slice
-            @test typeof(slice) == Pair{@NT(a::Int), @NT(b::Int)}
-            IndexedTable(Columns(z=[7]), Columns(y=[1]))
-    end
     x=IndexedTable(Columns([1,2]),Columns([1,2]))
     @test_throws ErrorException mapslices(x,()) do slice
         true
     end
     t = mapslices(x,()) do slice
-        @test typeof(slice) == Pair{Tuple{Int}, Tuple{Int}}
+        @test slice == IndexedTable(Columns([1]), Columns([1])) || slice == IndexedTable(Columns([2]), Columns([2]))
         IndexedTable(Columns([1]), ([1]))
     end
     @test t == IndexedTable(Columns([1,2], [1,1]), [1,1])


### PR DESCRIPTION
See #63 

One minor annoyance:

`keys(t::IndexedTable, col::Union{Symbol,Int})` here returns a `Columns` with 1 vector. To get the column, you'd have to do `column(keys(t), col)`... This is so that `keys(t, cols...)`  always works by returning `Columns`. There's an alternative where you could make `keys(t, col::Tuple)` return columns but `keys(t, col::Symbol)` return the vector and not have `keys(t, cols...)`. Not sure which one to go with. @JeffBezanson what do you think?