### PR TITLE
WIP: `by` and `with`

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -169,7 +169,7 @@ function column(t::IndexedTable, col::Symbol)
         return column(values(t), col)
     end
 
-    error("Couldn't find column named $n")
+    error("Couldn't find column named $col")
 end
 
 ## Column-wise iteration:

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -279,6 +279,7 @@ end
 as(f, src, dest) = As(f, src, dest)
 as(src, dest) = as(identity, src, dest)
 as(xs::AbstractArray, dest) = as(xs, nothing, dest)
+as(name::Symbol) = x -> as(x, name)
 
 _name(x::As) = x.dest
 function column(t::Union{IndexedTable, AbstractVector}, a::As)

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -187,6 +187,7 @@ columns(t::IndexedTable) = concat_tup(columns(keys(t)),
                                       columns(values(t)))
 
 _name(x::Union{Int, Symbol}) = x
+_name(x::AbstractArray) = 0
 function _output_tuple(which::Tuple)
     names = map(_name, which)
     if all(x->isa(x, Symbol), names)
@@ -271,16 +272,23 @@ values(t::IndexedTable, which...) = rows(values(t), which...)
 
 struct As{F}
     f::F
-    src::Union{Int, Symbol}
+    src::Union{Void, Int, Symbol}
     dest::Union{Int, Symbol}
 end
 
 as(f, src, dest) = As(f, src, dest)
 as(src, dest) = as(identity, src, dest)
+as(xs::AbstractArray, dest) = as(xs, nothing, dest)
 
 _name(x::As) = x.dest
 function column(t::Union{IndexedTable, AbstractVector}, a::As)
     a.f(column(t, a.src))
+end
+function column(t::Union{IndexedTable, AbstractVector}, a::As{<:AbstractVector})
+    a.f
+end
+function column(t::Union{IndexedTable, AbstractVector}, a::AbstractArray)
+    a
 end
 
 """

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -112,7 +112,7 @@ function refine_perm!(p, cols, c, x, y, lo, hi)
     i = lo
     while i < hi
         i1 = i+1
-        @inbounds while i1 <= hi && x[p[i1]] == x[p[i]]
+        @inbounds while i1 <= hi && roweq(x, p[i1], p[i])
             i1 += 1
         end
         i1 -= 1
@@ -218,6 +218,8 @@ end
     end
     ex
 end
+
+@inline roweq(x::AbstractVector, i, j) = x[i] == x[j]
 
 # uses number of columns from `d`, assuming `c` has more or equal
 # dimensions, for broadcast joins.

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -199,6 +199,7 @@ end
 # row operations
 
 copyrow!(I::Columns, i, src) = foreach(c->copyelt!(c, i, src), I.columns)
+pushrow!(to::Columns, from::Columns, i) = foreach((a,b)->push!(a, b[i]), to.columns, from.columns)
 
 @generated function rowless{D,C}(c::Columns{D,C}, i, j)
     N = length(C.parameters)

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -91,13 +91,16 @@ function ==(x::Columns, y::Columns)
     return true
 end
 
+sortedlabels(x::PooledArray) = x.refs
+sortedlabels{T<:Integer}(x::AbstractArray{T}) = x
+
 function sortperm(c::Columns)
     cols = c.columns
     x = cols[1]
     p = sortperm_fast(x)
     if length(cols) > 1
         y = cols[2]
-        refine_perm!(p, cols, 1, x, isa(y,PooledArray) ? y.refs : y, 1, length(x))
+        refine_perm!(p, cols, 1, x, sortedlabels(y), 1, length(x))
     end
     return p
 end
@@ -120,7 +123,7 @@ function refine_perm!(p, cols, c, x, y, lo, hi)
             sort_sub_by!(p, i, i1, y, order, temp)
             if c < nc-1
                 z = cols[c+2]
-                refine_perm!(p, cols, c+1, y, isa(z,PooledArray) ? z.refs : z, i, i1)
+                refine_perm!(p, cols, c+1, y, sortedlabels(z), i, i1)
             end
         end
         i = i1+1

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -91,8 +91,8 @@ function ==(x::Columns, y::Columns)
     return true
 end
 
-sortedlabels(x::PooledArray) = x.refs
-sortedlabels{T<:Integer}(x::AbstractArray{T}) = x
+sortproxy(x::PooledArray) = x.refs
+sortproxy{T<:Integer}(x::AbstractArray{T}) = x
 
 function sortperm(c::Columns)
     cols = c.columns
@@ -100,7 +100,7 @@ function sortperm(c::Columns)
     p = sortperm_fast(x)
     if length(cols) > 1
         y = cols[2]
-        refine_perm!(p, cols, 1, x, sortedlabels(y), 1, length(x))
+        refine_perm!(p, cols, 1, x, sortproxy(y), 1, length(x))
     end
     return p
 end
@@ -123,7 +123,7 @@ function refine_perm!(p, cols, c, x, y, lo, hi)
             sort_sub_by!(p, i, i1, y, order, temp)
             if c < nc-1
                 z = cols[c+2]
-                refine_perm!(p, cols, c+1, y, sortedlabels(z), i, i1)
+                refine_perm!(p, cols, c+1, y, sortproxy(z), i, i1)
             end
         end
         i = i1+1

--- a/src/join.jl
+++ b/src/join.jl
@@ -91,89 +91,127 @@ map(f, x::IndexedTable{T,D}, y::IndexedTable{S,D}) where {T,S,D} = naturaljoin(x
 
 # left join
 
-function leftjoin(left::IndexedTable, right::IndexedTable, op = IndexedTables.right)
+function leftjoin(left::IndexedTable, right::IndexedTable, op = IndexedTables.right;
+                  by=keyselector(left),
+                  with=valueselector(left),
+                  leftby=by, rightby=by,
+                  leftwith=with, rigthwith=with,
+                 )
     flush!(left); flush!(right)
-    lI, rI = left.index, right.index
-    lD, rD = left.data, right.data
-    ll, rr = length(lI), length(rI)
+    lI, rI = rows(left, leftby), rows(right, rightby)
+    lP, rP = sortperm(left, leftby), sortperm(right, rightby)
+    lD, rD = rows(left, leftwith), rows(right, with)
+
+    # allow right table to have different column names
 
     data = similar(lD)
-
-    i = j = 1
-
-    while i <= ll && j <= rr
-        c = rowcmp(lI, i, rI, j)
-        if c < 0
-            @inbounds data[i] = lD[i]
-            i += 1
-        elseif c == 0
-            @inbounds data[i] = op(lD[i], rD[j])
-            i += 1
-            j += 1
-        else
-            j += 1
-        end
-    end
-    data[i:ll] = lD[i:ll]
-
-    IndexedTable(copy(lI), data, presorted=true)
+    _leftjoin!(op, copy(lI), rI, lP, rP, lD, rD, data)
 end
 
-function leftjoin!(left::IndexedTable, right::IndexedTable, op = IndexedTables.right)
+function leftjoin!(left::IndexedTable, right::IndexedTable, op = IndexedTables.right;
+                  by=keyselector(left),
+                  with=valueselector(left),
+                  leftby=by, rightby=by,
+                  leftwith=with, rigthwith=with,
+                 )
     flush!(left); flush!(right)
-    lI, rI = left.index, right.index
-    lD, rD = left.data, right.data
+    lI, rI = rows(left, leftby), rows(right, rightby)
+    lP, rP = sortperm(left, leftby), sortperm(right, rightby)
+    lD, rD = rows(left, leftwith), rows(right, with)
+
+    # allow right table to have different column names
+
+    data = similar(lD)
+    _leftjoin!(op, lI, rI, lP, rP, lD, rD, lD)
+end
+
+function _leftjoin!(op, lI, rI, lP, rP, lD, rD, data)
     ll, rr = length(lI), length(rI)
+    datacols = astuple(columns(data))
+    rcols = astuple(columns(rD))
 
     i = j = 1
 
-    while i <= ll && j <= rr
-        c = rowcmp(lI, i, rI, j)
+    @inbounds while i <= ll && j <= rr
+        li = lP[i]
+        rj = rP[j]
+        c = rowcmp(lI, li, rI, rj)
         if c < 0
+            data[i] = lD[li]
             i += 1
         elseif c == 0
-            @inbounds lD[i] = op(lD[i], rD[j])
+            if isa(op, typeof(IndexedTables.right)) # optimization
+                foreach(datacols, rcols) do dc, rc
+                    @inbounds dc[i] = rc[rj]
+                end
+            else
+                data[i] = op(lD[li], rD[rj])
+            end
             i += 1
             j += 1
         else
             j += 1
         end
     end
-    left
+    if lD !== data
+        data[i:ll] = lD[i:ll]
+    end
+
+    if !isa(lP, Base.OneTo)
+        permute!(lI, lP)
+    end
+
+    IndexedTable(lI, data, presorted=true)
 end
 
 # asof join
 
-function asofjoin(left::IndexedTable, right::IndexedTable)
+function asofjoin(left::IndexedTable, right::IndexedTable;
+                  by=keyselector(left), with=valueselector(left),
+                  leftby=by, rightby=by,
+                  leftwith=with, rightwith=with,
+                 )
     flush!(left); flush!(right)
-    lI, rI = left.index, right.index
-    lD, rD = left.data, right.data
-    ll, rr = length(lI), length(rI)
+    lI, rI = rows(left, leftby), rows(right, rightby)
+    lP, rP = sortperm(left, leftby), sortperm(right, rightby)
+    lD, rD = rows(left, leftwith), rows(right, with)
 
     data = similar(lD)
+    _asofjoin!(copy(lI), rI, lP, rP, lD, rD, data)
+end
 
+function _asofjoin!(lI, rI, lP, rP, lD, rD, data)
+    ll, rr = length(lI), length(rI)
     i = j = 1
 
-    while i <= ll && j <= rr
-        c = rowcmp(lI, i, rI, j)
+    @inbounds while i <= ll && j <= rr
+        li = lP[i]
+        rj = rP[j]
+        c = rowcmp(lI, li, rI, rj)
         if c < 0
-            @inbounds data[i] = lD[i]
+            data[i] = lD[li]
             i += 1
-        elseif row_asof(lI, i, rI, j)  # all equal except last col left>=right
+        elseif row_asof(lI, li, rI, rj)  # all equal except last col left>=right
             j += 1
-            while j <= rr && row_asof(lI, i, rI, j)
+            while j <= rr && row_asof(lI, li, rI, rP[j])
                 j += 1
             end
             j -= 1
-            @inbounds data[i] = rD[j]
+            data[i] = rD[rP[j]]
             i += 1
         else
             j += 1
         end
     end
-    data[i:ll] = lD[i:ll]
+    if lD !== data
+        data[i:ll] = lD[i:ll]
+    end
 
-    IndexedTable(copy(lI), data, presorted=true)
+    if !isa(lP, Base.OneTo)
+        permute!(lI, lP)
+    end
+
+    IndexedTable(lI, data, presorted=true)
 end
 
 # merge - union join

--- a/src/join.jl
+++ b/src/join.jl
@@ -2,33 +2,54 @@ export naturaljoin, innerjoin, leftjoin, asofjoin, leftjoin!
 
 ## Joins
 
-# Natural Join (Both NDSParse arrays must have the same number of columns, in the same order)
-
-function naturaljoin(left::IndexedTable, right::IndexedTable, op)
-    lD, rD = left.data, right.data
-    _naturaljoin(left, right, op, similar(lD, typeof(op(lD[1],rD[1])), 0))
+function naturaljoin(left::IndexedTable, right::IndexedTable, op; kwargs...)
+    naturaljoin(left, right; op=op, kwargs...)
 end
 
 const innerjoin = naturaljoin
 
-combine_op(a, b) = tuple
-combine_op(a::Columns, b::Columns) = (l, r)->(l..., r...)
-combine_op(a, b::Columns) = (l, r)->(l, r...)
-combine_op(a::Columns, b) = (l, r)->(l..., r)
 similarz(a) = similar(a,0)
 
-function naturaljoin(left::IndexedTable, right::IndexedTable)
-    lD, rD = left.data, right.data
-    op = combine_op(lD, rD)
-    cols(v) = (v,)
-    cols(v::Columns) = v.columns
-    _naturaljoin(left, right, op, Columns((map(similarz,cols(lD))...,map(similarz,cols(rD))...)))
+function naturaljoin(left::IndexedTable, right::IndexedTable;
+                     by=keyselector(left),
+                     leftby=by, rightby=by,
+                     leftwith=valueselector(left),
+                     op=nothing,
+                     rightwith=valueselector(right))
+
+    flush!(left); flush!(right)
+
+    lD, rD = rows(left, leftwith), rows(right, rightwith)
+    lO = nothing
+    rO = nothing
+
+    if op === nothing
+        tup = if eltype(lD) <: NamedTuple && eltype(rD) <: NamedTuple
+            namedtuple(fieldnames(eltype(lD))...,
+                       fieldnames(eltype(rD))...)
+        else
+            tuple
+        end
+        lO = isa(lD, Columns) ? rows(map(similarz, columns(lD))) : similarz(lD)
+        rO = isa(rD, Columns) ? rows(map(similarz, columns(rD))) : similarz(rD)
+        data = Columns(tup(columns(lO)...,
+                           columns(rO)...))
+    else
+        outT = _promote_op(op, eltype(lD), eltype(rD))
+        if outT <: Tup
+            data = Columns(map(x->Vector{x}, [outT.parameters...])...;
+                           names=outT<:Tuple ? nothing : fieldnames(outT))
+        else
+            data = Vector{outT}(0)
+        end
+    end
+
+    lI, rI = rows(left, leftby), rows(right, rightby)
+    lP, rP = sortperm(left, leftby), sortperm(right, rightby)
+    _naturaljoin(op, data, lO, rO, lI, rI, lD, rD, lP, rP)
 end
 
-function _naturaljoin(left::IndexedTable, right::IndexedTable, op, data)
-    flush!(left); flush!(right)
-    lI, rI = left.index, right.index
-    lD, rD = left.data, right.data
+function _naturaljoin(op, data, lO, rO, lI, rI, lD, rD, lP, rP)
     ll, rr = length(lI), length(rI)
 
     # Guess the length of the result
@@ -42,10 +63,17 @@ function _naturaljoin(left::IndexedTable, right::IndexedTable, op, data)
     i = j = 1
 
     while i <= ll && j <= rr
-        c = rowcmp(lI, i, rI, j)
+        li = lP[i]
+        rj = rP[j]
+        c = rowcmp(lI, li, rI, rj)
         if c == 0
-            push!(I, lI[i])
-            push!(data, op(lD[i], rD[j]))
+            push!(I, lI[li])
+            if op === nothing
+                push!(lO, lD[li])
+                push!(rO, rD[rj])
+            else
+                push!(data, op(lD[li], rD[rj]))
+            end
             i += 1
             j += 1
         elseif c < 0

--- a/src/join.jl
+++ b/src/join.jl
@@ -396,7 +396,7 @@ function _broadcast_trailing!(f, A::IndexedTable, B::IndexedTable, C::IndexedTab
         c = rowcmp(lI, i, rI, j)
         if c == 0
             while true
-                push!(I, lI[i])
+                pushrow!(I, lI, i)
                 push!(data, f(lD[i], rD[j]))
                 i += 1
                 (i <= ll && rowcmp(lI, i, rI, j)==0) || break
@@ -435,7 +435,7 @@ function _bcast_loop!(f::Function, A::IndexedTable, B::IndexedTable, C::IndexedT
             # `iperm`, leaving some 0 gaps to be filtered out later.
             cnt += 1
             iperm[j] = cnt
-            push!(A.index, B.index[j])
+            pushrow!(A.index, B.index, j)
             push!(A.data, f(B.data[j], Ck))
         end
         jlo, klo = jhi, klo+1

--- a/src/join.jl
+++ b/src/join.jl
@@ -95,12 +95,12 @@ function leftjoin(left::IndexedTable, right::IndexedTable, op = IndexedTables.ri
                   by=keyselector(left),
                   with=valueselector(left),
                   leftby=by, rightby=by,
-                  leftwith=with, rigthwith=with,
+                  leftwith=with, rightwith=with,
                  )
     flush!(left); flush!(right)
     lI, rI = rows(left, leftby), rows(right, rightby)
     lP, rP = sortperm(left, leftby), sortperm(right, rightby)
-    lD, rD = rows(left, leftwith), rows(right, with)
+    lD, rD = rows(left, leftwith), rows(right, rightwith)
 
     # allow right table to have different column names
 
@@ -148,7 +148,6 @@ function _leftjoin!(op, lI, rI, lP, rP, lD, rD, data)
                 data[i] = op(lD[li], rD[rj])
             end
             i += 1
-            j += 1
         else
             j += 1
         end

--- a/src/join.jl
+++ b/src/join.jl
@@ -411,11 +411,12 @@ function _broadcast_trailing!(f, A::IndexedTable, B::IndexedTable, C::IndexedTab
     return A
 end
 
-function _bcast_loop!(f::Function, A::IndexedTable, B::IndexedTable, C::IndexedTable, B_common, B_perm)
+function _bcast_loop!(f::Function, dA, B::IndexedTable, C::IndexedTable, B_common, B_perm)
     m, n = length(B_perm), length(C)
     jlo = klo = 1
     iperm = zeros(Int, m)
     cnt = 0
+    idxperm = Int32[]
     @inbounds while jlo <= m && klo <= n
         pjlo = B_perm[jlo]
         x = rowcmp(B_common, pjlo, C.index, klo)
@@ -434,12 +435,12 @@ function _bcast_loop!(f::Function, A::IndexedTable, B::IndexedTable, C::IndexedT
             # `iperm`, leaving some 0 gaps to be filtered out later.
             cnt += 1
             iperm[j] = cnt
-            pushrow!(A.index, B.index, j)
-            push!(A.data, f(B.data[j], Ck))
+            push!(idxperm, j)
+            push!(dA, f(B.data[j], Ck))
         end
         jlo, klo = jhi, klo+1
     end
-    filter!(i->i!=0, iperm)
+    B.index[idxperm], filter!(i->i!=0, iperm)
 end
 
 # broadcast C over B, into A. assumes A and B have same dimensions and ndims(B) >= ndims(C)
@@ -460,7 +461,8 @@ function _broadcast!(f::Function, A::IndexedTable, B::IndexedTable, C::IndexedTa
     B_common_cols = Columns(B.index.columns[common])
     B_perm = sortperm(B_common_cols)
     if C_common == C_dims
-        iperm = _bcast_loop!(f, A, B, C, B_common_cols, B_perm)
+        idx, iperm = _bcast_loop!(f, values(A), B, C, B_common_cols, B_perm)
+        A = IndexedTable(idx, values(A), copy=false, presorted=true)
         if !issorted(A.index)
             permute!(A.index, iperm)
             copy!(A.data, A.data[iperm])

--- a/src/query.jl
+++ b/src/query.jl
@@ -27,6 +27,8 @@ function Base.select(arr::IndexedTable, which::DimName...; agg=nothing)
     if eltype(keys(arr)) <: NamedTuple
         fn = fieldnames(eltype(keys(arr)))
         names = map(x->isa(x, Int) ? fn[x] : x, which)
+    else
+        names = which
     end
     IndexedTable(keys(arr, (names...)), values(arr), agg=agg, copy=true)
 end
@@ -86,6 +88,7 @@ function keyselector(t)
 end
 
 function Base.sortperm(t::IndexedTable, by)
+    @show fieldnames(columns(t)), by
 
     canonorder = map(i->colindex(eltype(keys(t)), eltype(t), i), by)
 

--- a/src/query.jl
+++ b/src/query.jl
@@ -100,7 +100,7 @@ function Base.sortperm(t::IndexedTable, by)
     if sorted_cols > 0
         nxtcol = bycols[sorted_cols+1]
         p = [1:length(t);]
-        refine_perm!(p, bycols, sorted_cols, rows(t, by[1:sorted_cols]), sortedlabels(nxtcol), 1, length(t))
+        refine_perm!(p, bycols, sorted_cols, rows(t, by[1:sorted_cols]), sortproxy(nxtcol), 1, length(t))
         return p
     else
         return sortperm(rows(bycols))

--- a/src/query.jl
+++ b/src/query.jl
@@ -24,7 +24,11 @@ Select a subset of index columns. If the resulting array has duplicate index ent
 """
 function Base.select(arr::IndexedTable, which::DimName...; agg=nothing)
     flush!(arr)
-    IndexedTable(keys(arr, (which...)), values(arr), agg=agg, copy=true)
+    if eltype(keys(arr)) <: NamedTuple
+        fn = fieldnames(eltype(keys(arr)))
+        names = map(x->isa(x, Int) ? fn[x] : x, which)
+    end
+    IndexedTable(keys(arr, (names...)), values(arr), agg=agg, copy=true)
 end
 
 # Filter on data field

--- a/src/query.jl
+++ b/src/query.jl
@@ -10,11 +10,10 @@ Example: `select(arr, 1 => x->x>10, 3 => x->x!=10 ...)`
 function Base.select(arr::IndexedTable, conditions::Pair...)
     flush!(arr)
     indxs = [1:length(arr);]
-    cols = arr.index.columns
     for (c,f) in conditions
-        filt_by_col!(f, cols[c], indxs)
+        filt_by_col!(f, column(arr, c), indxs)
     end
-    IndexedTable(Columns(map(x->x[indxs], cols)), arr.data[indxs], presorted=true)
+    IndexedTable(keys(arr)[indxs], values(arr)[indxs], presorted=true)
 end
 
 """
@@ -25,15 +24,15 @@ Select a subset of index columns. If the resulting array has duplicate index ent
 """
 function Base.select(arr::IndexedTable, which::DimName...; agg=nothing)
     flush!(arr)
-    IndexedTable(Columns(arr.index.columns[[which...]]), arr.data, agg=agg, copy=true)
+    IndexedTable(keys(arr, (which...)), values(arr), agg=agg, copy=true)
 end
 
 # Filter on data field
 function Base.filter(fn::Function, arr::IndexedTable)
     flush!(arr)
-    data = arr.data
+    data = values(arr)
     indxs = filter(i->fn(data[i]), eachindex(data))
-    IndexedTable(Columns(map(x->x[indxs], arr.index.columns)), data[indxs], presorted=true)
+    IndexedTable(keys(arr)[indxs], data[indxs], presorted=true)
 end
 
 # aggregation

--- a/src/query.jl
+++ b/src/query.jl
@@ -100,7 +100,7 @@ function Base.sortperm(t::IndexedTable, by)
     if sorted_cols > 0
         nxtcol = bycols[sorted_cols+1]
         p = [1:length(t);]
-        refine_perm!(p, bycols, sorted_cols, rows(t, by[1:sorted_cols]), isa(nxtcol, PooledArray) ? nxtcol.refs : nxtcol, 1, length(t))
+        refine_perm!(p, bycols, sorted_cols, rows(t, by[1:sorted_cols]), sortedlabels(nxtcol), 1, length(t))
         return p
     else
         return sortperm(rows(bycols))

--- a/src/query.jl
+++ b/src/query.jl
@@ -44,21 +44,25 @@ end
 Combine adjacent rows with equal indices using the given 2-argument reduction function,
 in place.
 """
-function aggregate!(f, x::IndexedTable)
-    idxs, data = x.index, x.data
+function aggregate!(f, x::IndexedTable;
+                    by = keyselector(x),
+                    with = valueselector(x),
+                    presorted = false)
+    idxs, data = rows(x, by), rows(x, with)
     n = length(idxs)
     newlen = 0
     i1 = 1
+    perm = presorted ? Base.OneTo(length(idxs)) : sortperm(x, by)
     while i1 <= n
-        val = data[i1]
+        val = data[perm[i1]]
         i = i1+1
-        while i <= n && roweq(idxs, i, i1)
-            val = f(val, data[i])
+        while i <= n && roweq(idxs, perm[i], perm[i1])
+            val = f(val, data[perm[i]])
             i += 1
         end
         newlen += 1
         if newlen != i1
-            copyrow!(idxs, newlen, i1)
+            copyrow!(idxs, newlen, perm[i1])
         end
         data[newlen] = val
         i1 = i
@@ -68,69 +72,87 @@ function aggregate!(f, x::IndexedTable)
     x
 end
 
-"""
-`aggregate(f::Function, arr::IndexedTable)`
+function valueselector(t)
+    isa(values(t), Columns) ?
+        ((ndims(t) + (1:nfields(eltype(values(t)))))...) :
+        ndims(t) + 1
+end
 
-Combine adjacent rows with equal indices using the given 2-argument reduction function,
-returning the result in a new array.
-"""
-function aggregate(f, x::IndexedTable)
-    idxs, data = aggregate_to(f, x.index, x.data)
-    IndexedTable(idxs, data, presorted=true, copy=false)
+function keyselector(t)
+    ntuple(identity, ndims(t))
+end
+
+function Base.sortperm(t::IndexedTable, by)
+
+    canonorder = map(i->colindex(eltype(keys(t)), eltype(t), i), by)
+
+    sorted_cols = 0
+    for (i, c) in enumerate(canonorder)
+        c != i && break
+        sorted_cols += 1
+    end
+
+    if sorted_cols == length(by)
+        # first n index columns
+        return Base.OneTo(length(t))
+    end
+
+    bycols = columns(t, by)
+    if sorted_cols > 0
+        nxtcol = bycols[sorted_cols+1]
+        p = [1:length(t);]
+        refine_perm!(p, bycols, sorted_cols, rows(t, by[1:sorted_cols]), isa(nxtcol, PooledArray) ? nxtcol.refs : nxtcol, 1, length(t))
+        return p
+    else
+        return sortperm(rows(bycols))
+    end
+end
+
+function aggregate(f, t::IndexedTable;
+                   by = keyselector(t),
+                   with = valueselector(t),
+                   presorted=false)
+    bycol = rows(t, by)
+    perm = presorted ? Base.OneTo(length(bycol)) : sortperm(t, by)
+    IndexedTable(aggregate_to(f, bycol, rows(t, with), perm)...; presorted=true)
+end
+
+function colindex(K, V, col)
+    if isa(col, Int) && 1 <= col <= nfields(K) + nfields(V)
+        return col
+    elseif isa(col, Symbol)
+        if col in fieldnames(K)
+            return findfirst(fieldnames(K), col)
+        elseif col in fieldnames(V)
+            return nfields(K) + findfirst(fieldnames(V), col)
+        end
+    elseif isa(col, As)
+        return colindex(K, V, col.src)
+    end
+    error("column $col not found.")
 end
 
 # aggregate out of place, building up new indexes and data
-function aggregate_to(f, src_idxs, src_data)
+function aggregate_to(f, src_idxs, src_data, perm=Base.OneTo(length(src_idxs)))
     dest_idxs, dest_data = similar(src_idxs,0), similar(src_data,0)
     n = length(src_idxs)
     i1 = 1
     while i1 <= n
-        val = src_data[i1]
+        val = src_data[perm[i1]]
         i = i1+1
-        while i <= n && roweq(src_idxs, i, i1)
-            val = f(val, src_data[i])
+        while i <= n && roweq(src_idxs, perm[i], perm[i1])
+            val = f(val, src_data[perm[i]])
             i += 1
         end
-        push!(dest_idxs, src_idxs[i1])
+        push!(dest_idxs, src_idxs[perm[i1]])
         push!(dest_data, val)
         i1 = i
     end
     dest_idxs, dest_data
 end
 
-# returns a new vector where each element is computed by applying `f` to a vector of
-# all values associated with equal indexes. idxs is modified in place.
-function _aggregate_vec!(f, idxs::Columns, data)
-    n = length(idxs)
-    local newdata
-    newlen = 0
-    i1 = 1
-    while i1 <= n
-        i = i1+1
-        while i <= n && roweq(idxs, i, i1)
-            i += 1
-        end
-        val = f(data[i1:(i-1)])
-        if newlen == 0
-            newdata = [val]
-            if isa(val, Tup)
-                newdata = convert(Columns, newdata)
-            end
-        else
-            push!(newdata, val)
-        end
-        newlen += 1
-        if newlen != i1
-            copyrow!(idxs, newlen, i1)
-        end
-        i1 = i
-    end
-    resize!(idxs, newlen)
-    newlen==0 ? Union{}[] : newdata
-end
-
 # out of place vector aggregation
-function aggregate_vec_to(f, src_idxs, src_data)
+function aggregate_vec_to(f, src_idxs, src_data, perm=Base.OneTo(length(src_idxs)))
     n = length(src_idxs)
     dest_idxs = similar(src_idxs,0)
     local newdata
@@ -138,10 +160,10 @@ function aggregate_vec_to(f, src_idxs, src_data)
     i1 = 1
     while i1 <= n
         i = i1+1
-        while i <= n && roweq(src_idxs, i, i1)
+        while i <= n && roweq(src_idxs, perm[i], perm[i1])
             i += 1
         end
-        val = f(src_data[i1:(i-1)])
+        val = f(src_data[perm[i1:(i-1)]])
         if newlen == 0
             newdata = [val]
             if isa(val, Tup)
@@ -151,24 +173,24 @@ function aggregate_vec_to(f, src_idxs, src_data)
             push!(newdata, val)
         end
         newlen += 1
-        push!(dest_idxs, src_idxs[i1])
+        push!(dest_idxs, src_idxs[perm[i1]])
         i1 = i
     end
     (dest_idxs, (newlen==0 ? Union{}[] : newdata))
 end
 
 # vector aggregation, not modifying or computing new indexes. only returns new data.
-function _aggregate_vec(f, idxs::Columns, data)
+function _aggregate_vec(f, idxs, data, perm)
     n = length(idxs)
     local newdata
     newlen = 0
     i1 = 1
     while i1 <= n
         i = i1+1
-        while i <= n && roweq(idxs, i, i1)
+        while i <= n && roweq(idxs, perm[i], perm[i1])
             i += 1
         end
-        val = f(data[i1:(i-1)])
+        val = f(data[perm[i1:(i-1)]])
         if newlen == 0
             newdata = [val]
             if isa(val, Tup)
@@ -183,24 +205,30 @@ function _aggregate_vec(f, idxs::Columns, data)
     newlen==0 ? Union{}[] : newdata
 end
 
+function _aggregate_vec(ks, vs, names, funs, perm)
+    n = length(funs)
+    n == 0 && return IndexedTable(ks, vs, presorted=true)
+    n != length(names) && return IndexedTable(ks, vs, presorted=true)
+    datacols = Any[ _aggregate_vec(funs[i], ks, vs, perm) for i = 1:n-1 ]
+    idx, lastcol = aggregate_vec_to(funs[n], ks, vs)
+    IndexedTable(idx, Columns(datacols..., lastcol, names = names), presorted=true)
+end
+
+
 """
 `aggregate_vec(f::Function, x::IndexedTable)`
 
 Combine adjacent rows with equal indices using a function from vector to scalar,
 e.g. `mean`.
 """
-function aggregate_vec(f, x::IndexedTable)
-    idxs, data = aggregate_vec_to(f, x.index, x.data)
-    IndexedTable(idxs, data, presorted=true, copy=false)
-end
+function aggregate_vec(f, x::IndexedTable;
+                       by=keyselector(x),
+                       with=valueselector(x),
+                       presorted=false)
 
-function _aggregate_vec(x::IndexedTable, names::Vector, funs::Vector)
-    n = length(funs)
-    n == 0 && return x
-    n != length(names) && return x
-    datacols = Any[ _aggregate_vec(funs[i], x.index, x.data) for i = 1:n-1 ]
-    idx, lastcol = aggregate_vec_to(funs[n], x.index, x.data)
-    IndexedTable(idx, Columns(datacols..., lastcol, names = names), presorted=true)
+    perm = presorted ? Base.OneTo(length(x)) : sortperm(x, by)
+    idxs, data = aggregate_vec_to(f, rows(x, by), rows(x, with), perm)
+    IndexedTable(idxs, data, presorted=true, copy=false)
 end
 
 """
@@ -209,8 +237,14 @@ end
 Combine adjacent rows with equal indices using multiple functions from vector to scalar.
 The result has multiple data columns, one for each function, named based on the functions.
 """
-function aggregate_vec(fs::Vector, x::IndexedTable)
-    _aggregate_vec(x, map(Symbol, fs), fs)
+function aggregate_vec(fs::Vector, x::IndexedTable;
+                       names=map(Symbol, fs),
+                       by=keyselector(x),
+                       with=valueselector(x),
+                       presorted=false)
+
+    perm = presorted ? Base.OneTo(length(x)) : sortperm(x, by)
+    _aggregate_vec(rows(x, by), rows(x, with), names, fs, perm)
 end
 
 """
@@ -219,8 +253,8 @@ end
 Combine adjacent rows with equal indices using multiple functions from vector to scalar.
 The result has multiple data columns, one for each function provided by `funs`.
 """
-function aggregate_vec(x::IndexedTable; funs...)
-    _aggregate_vec(x, [x[1] for x in funs], [x[2] for x in funs])
+function aggregate_vec(t::IndexedTable; funs...)
+    aggregate_vec([x[2] for x in funs], t, names = [x[1] for x in funs])
 end
 
 
@@ -275,20 +309,12 @@ reducedim(f, x::IndexedTable, dims::Symbol) = reducedim(f, x, [dims])
 Like `reducedim`, except uses a function mapping a vector of values to a scalar instead
 of a 2-argument scalar function.
 """
-function reducedim_vec(f, x::IndexedTable, dims)
+function reducedim_vec(f, x::IndexedTable, dims; with=valueselector(x))
     keep = setdiff([1:ndims(x);], map(d->fieldindex(x.index.columns,d), dims))
     if isempty(keep)
         throw(ArgumentError("to remove all dimensions, use `reduce(f, A)`"))
     end
-    cols = Columns(x.index.columns[[keep...]])
-    if issorted(cols)
-        idxs, d = aggregate_vec_to(f, cols, x.data)
-    else
-        p = sortperm(cols)
-        idxs = cols[p]
-        xd = x.data[p]
-        d = _aggregate_vec!(f, idxs, xd)
-    end
+    idxs, d = aggregate_vec_to(f, keys(x, (keep...)), columns(x, with), sortperm(x, (keep...)))
     IndexedTable(idxs, d, presorted=true, copy=false)
 end
 

--- a/src/query.jl
+++ b/src/query.jl
@@ -88,8 +88,6 @@ function keyselector(t)
 end
 
 function Base.sortperm(t::IndexedTable, by)
-    @show fieldnames(columns(t)), by
-
     canonorder = map(i->colindex(eltype(keys(t)), eltype(t), i), by)
 
     sorted_cols = 0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -169,7 +169,7 @@ end
 
 # sortperm with counting sort
 
-sortperm_fast(x) = sortperm_fast(sortedlabels(x))
+sortperm_fast(x) = sortperm_fast(sortproxy(x))
 
 function sortperm_fast(v::Vector{T}) where T<:Integer
     n = length(v)
@@ -300,7 +300,7 @@ function _int_getindex!(p, idxs)
     idxs
 end
 
-function sortedlabels(xs)
+function sortproxy(xs)
     uq, labels = _label(xs)
     p = convert(Vector{eltype(labels)}, invperm(sortperm(uq)))
     _int_getindex!(p, labels)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -37,6 +37,7 @@ let
     y = IndexedTable(Columns(a=[1,1], b=[1,2]), [3,4])
 
     @test column(x, :a) == [1,1]
+    @test column(x, [5,6]) == [5,6]
     @test column(x, :b) == [1,2]
     @test column(x, :c) == [3,4]
     @test column(x, 3) == [3,4]
@@ -50,6 +51,8 @@ let
     @test rows(x, :b) == [1, 2]
     @test rows(x, (:b, :c)) == [@NT(b=1,c=3), @NT(b=2,c=4)]
     @test rows(x, (:c, as(-, :b, :x))) == [@NT(c=3, x=-1),@NT(c=4, x=-2)]
+    @test rows(x, (:c, as([1,2], :x))) == [@NT(c=3, x=1),@NT(c=4, x=2)]
+    @test rows(x, (:c, [1,2])) == [(3,1), (4,2)]
 
     @test keys(x) == [@NT(a=1,b=1), @NT(a=1,b=2)]
     @test keys(x, :a) == [1, 1]

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -51,7 +51,7 @@ let
     @test rows(x, :b) == [1, 2]
     @test rows(x, (:b, :c)) == [@NT(b=1,c=3), @NT(b=2,c=4)]
     @test rows(x, (:c, as(-, :b, :x))) == [@NT(c=3, x=-1),@NT(c=4, x=-2)]
-    @test rows(x, (:c, as([1,2], :x))) == [@NT(c=3, x=1),@NT(c=4, x=2)]
+    @test rows(x, (:c, [1,2] |> as(:x))) == [@NT(c=3, x=1),@NT(c=4, x=2)]
     @test rows(x, (:c, [1,2])) == [(3,1), (4,2)]
 
     @test keys(x) == [@NT(a=1,b=1), @NT(a=1,b=2)]


### PR DESCRIPTION
1) Adds `sortperm` on IndexedTable by a subset of columns which uses the existing sortedness of indexed columns.
2) `sortproxy` - makes a UInt<smallest> identically sorted label array for any array (O(n)) -- can then be used for `O(n)` sort/perm
2) Adds ability to aggregate and perform joins in a custom permute order
3) Uses 1) & 2) to allow aggregation by combinations of indexed and non-indexed columns (kinda) efficiently. Any improvements to `sortperm` / `refine_perm!` should improve aggregation performance.

API changes:
- `aggregate`, `aggregate_vec` and `aggregate!` take `by` and `with` keyword arguments (column name / number or tuple of column names / numbers). Aggregation is done by `by` columns, reduction is done with the `with` column(s).
- `select(arr, conditions::Pair...)` can now take Pairs of column name => functions where the column name can be both key or value columns
- `reducedim()` takes a `with` kwarg which is passed to f. (also deleted `_aggregate_vec!` no longer needed here)
- `innerjoin`, `leftjoin` and `asofjoin` take `by`, `with`, `leftby`, `rightby`, `leftwith`, `rightwith`

TODO:
- [ ] benchmark the joins
- [ ] implement options for `merge`
- [ ] tests