### PR TITLE
RFC: sorting tables

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -7,7 +7,7 @@ using NamedTuples, PooledArrays
 import Base:
     show, eltype, length, getindex, setindex!, ndims, map, convert, keys, values,
     ==, broadcast, empty!, copy, similar, sum, merge, merge!, mapslices,
-    permutedims, reducedim, serialize, deserialize
+    permutedims, reducedim, serialize, deserialize, sort, sort!
 
 export NDSparse, flush!, aggregate!, aggregate_vec, where, pairs, convertdim, columns, column, rows,
     itable, update!, aggregate, reducedim_vec, dimlabels

--- a/src/table.jl
+++ b/src/table.jl
@@ -422,18 +422,59 @@ end
 
 Base.values(t::NextTable) = rows(t)
 
-sort(t::NextTable, by...; select = Tuple(colnames(t)), kwargs...) =
+"""
+`sort(t[, by::Selection]; select::Selection, kwargs...)`
+
+Sort rows by `by`. All of `Base.sort` keywords can be used.
+
+# Examples
+
+```jldoctest sort
+julia> t=table([1,1,1,2,2,2], [1,1,2,2,1,1], [1,2,3,4,5,6],
+names=[:x,:y,:z]);
+
+julia> sort(t, :z; select = (:y, :z), rev = true)
+Table with 6 rows, 2 columns:
+y  z
+────
+1  6
+1  5
+2  4
+2  3
+1  2
+1  1
+```
+"""
+sort(t::NextTable, by...; select = valuenames(t), kwargs...) =
     table(rows(t, select)[sortperm(rows(t, by...); kwargs...)], copy = false)
 
-function sort!(t::NextTable; kwargs...)
-    isempty(t.pkey) || error("Tables with primary keys can't be sorted in place")
-    sort!(rows(t); kwargs...)
-    t
-end
+"""
+`sort!(t[, by::Selection]; kwargs...)`
 
-function sort!(t::NextTable, by; kwargs...)
+Sort rows by `by` in place. All of `Base.sort` keywords can be used.
+
+# Examples
+
+```jldoctest sort!
+julia> t=table([1,1,1,2,2,2], [1,1,2,2,1,1], [1,2,3,4,5,6],
+names=[:x,:y,:z]);
+
+julia> sort!(t, :z, rev = true);
+
+julia> t
+Table with 6 rows, 3 columns:
+x  y  z
+───────
+2  1  6
+2  1  5
+2  2  4
+1  2  3
+1  1  2
+1  1  1
+"""
+function sort!(t::NextTable, by...; kwargs...)
     isempty(t.pkey) || error("Tables with primary keys can't be sorted in place")
-    Base.permute!!(rows(t), sortperm(rows(t, by); kwargs...))
+    permute!(rows(t), sortperm(rows(t, by...); kwargs...))
     t
 end
 

--- a/src/table.jl
+++ b/src/table.jl
@@ -422,6 +422,21 @@ end
 
 Base.values(t::NextTable) = rows(t)
 
+sort(t::NextTable, by...; select = Tuple(colnames(t)), kwargs...) =
+    table(rows(t, select)[sortperm(rows(t, by...); kwargs...)], copy = false)
+
+function sort!(t::NextTable; kwargs...)
+    isempty(t.pkey) || error("Tables with primary keys can't be sorted in place")
+    sort!(rows(t); kwargs...)
+    t
+end
+
+function sort!(t::NextTable, by; kwargs...)
+    isempty(t.pkey) || error("Tables with primary keys can't be sorted in place")
+    Base.permute!!(rows(t), sortperm(rows(t, by); kwargs...))
+    t
+end
+
 """
     excludecols(itr, cols)
 

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -2,7 +2,7 @@ using Base.Test
 using IndexedTables
 using PooledArrays
 using NamedTuples
-using DataVales
+using DataValues
 import IndexedTables: update!, pkeynames, pkeys, excludecols, sortpermby, primaryperm, best_perm_estimate
 
 let c = Columns([1,1,1,2,2], [1,2,4,3,5]),

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -421,6 +421,15 @@ end
     @test best_perm_estimate(perms, [3,1]) == (0, nothing)
 end
 
+@testset "sort" begin
+    t = table(collect(1:10), collect(10:-1:1), names = [:x, :y])
+    @test columns(sort(t, rev = true), :x) == collect(10:-1:1)
+    @test columns(sort(t, :y), :y) == collect(1:10)
+    sort!(t)
+    @test columns(t, :x) == collect(1:10)
+    sort!(t, :y)
+    @test columns(t, :y) == collect(1:10)
+end
 
 @testset "reindex" begin
     t = table([2, 1], [1, 3], [4, 5], names=[:x, :y, :z], pkey=(1, 2))


### PR DESCRIPTION
I tried implementing sorting for tables. I'm not sure about the API (for example, do we want `sort!`? do we want the ability to select the output?) and performance (`sortperm` seems 2x slower than `sort` yet it's pretty useful to sort a table wrt one column). In `sort!` I put two methods explicitly as the method without a `by` can be made more performant, not sure whether that's worth it though.

Example use:

```julia
julia> t = table(rand(10), rand(10), names = [:x, :y]);

julia> sort(t, rev = true) #reverse of standard lexicographic of Tuples
Table with 10 rows, 2 columns:
x         y
──────────────────
0.968263  0.690031
0.895568  0.736328
0.760924  0.492825
0.65686   0.267379
0.527287  0.212894
0.511014  0.991095
0.484162  0.544516
0.237564  0.731677
0.181119  0.702376
0.03072   0.579739

julia> sort(t, :y)
Table with 10 rows, 2 columns:
x         y
──────────────────
0.527287  0.212894
0.65686   0.267379
0.760924  0.492825
0.484162  0.544516
0.03072   0.579739
0.968263  0.690031
0.181119  0.702376
0.237564  0.731677
0.895568  0.736328
0.511014  0.991095

julia> sort!(t, :y, rev = true);

julia> t
Table with 10 rows, 2 columns:
x         y
──────────────────
0.511014  0.991095
0.895568  0.736328
0.237564  0.731677
0.181119  0.702376
0.968263  0.690031
0.03072   0.579739
0.484162  0.544516
0.760924  0.492825
0.65686   0.267379
0.527287  0.212894

```

Let me know what you think (I can add docs and tests once the API is figured out).