### PR TITLE
WIP: added onall to summarize all columns

### DIFF
--- a/src/selection.jl
+++ b/src/selection.jl
@@ -1,4 +1,4 @@
-export dropna, selectkeys, selectvalues, ApplyColwise, Not, Keys
+export dropna, selectkeys, selectvalues, Not, Keys
 
 """
 `select(t::Table, which::Selection)`
@@ -143,23 +143,6 @@ end
 function selectvalues(x::NDSparse, which; kwargs...)
     ndsparse(keys(x), rows(values(x), which); kwargs...)
 end
-
-struct ApplyColwise{N, T<:Tuple}
-    functions::T
-    names::NTuple{N, Symbol}
-end
-
-ApplyColwise(args...) = ApplyColwise(args)
-ApplyColwise(t::Tuple) = ApplyColwise(t, map(Symbol,t))
-
-function (ac::ApplyColwise)(t::Union{AbstractIndexedTable, Columns})
-    func = Tuple(Symbol(s, :_, n) => s => f for s in colnames(t),
-        (f, n) in zip(ac.functions, ac.names))
-    fs, input, S = init_inputs(func, t, reduced_type, true)
-    _apply(fs, fs isa Tup ? columns(input) : input)
-end
-
-(ac::ApplyColwise)(t) = (ac::ApplyColwise)(convert(Columns, t))
 
 struct Not{T}
     names::T

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -828,6 +828,16 @@ end
                         NDSparse([1, 1], [2, 3], Columns(maxv=[4, 5], minv=[1, 0]))
 end
 
+@testset "colwise" begin
+    a = table([1,3,5], [2,2,2], names = [:x, :y])
+    @test ApplyColwise(mean, std)(a) ==
+        @NT(x_mean = 3.0, y_mean = 2.0, x_std = 2.0, y_std = 0.0)
+    @test ApplyColwise(mean, std)(collect(a)) == ApplyColwise(mean, std)(a)
+    @test ApplyColwise(mean, std)([1,2,3]) == @NT(mean = 2.0, std = 1.0)
+    @test ApplyColwise((mean, std), (:m, :s))(a) ==
+        @NT(x_m = 3.0, y_m = 2.0, x_s = 2.0, y_s = 0.0)
+end
+
 @testset "select" begin
     a = table([12,21,32], [52,41,34], [11,53,150], pkey=[1,2])
     b = table([12,23,32], [52,43,34], [56,13,10], pkey=[1,2])


### PR DESCRIPTION
This adds 3 special selectors. `OnAll` to apply a list of functions to all columns, `Not` for the complementary selection and `Keys` to select the primary keys. This allows:

```julia
Main> using JuliaDB, IndexedTables

Main> iris = loadtable("/Users/pietro/downloads/iris.csv")
Table with 150 rows, 5 columns:
SepalLength  SepalWidth  PetalLength  PetalWidth  Species
─────────────────────────────────────────────────────────────
5.1          3.5         1.4          0.2         "setosa"
4.9          3.0         1.4          0.2         "setosa"
4.7          3.2         1.3          0.2         "setosa"
4.6          3.1         1.5          0.2         "setosa"
⋮
6.5          3.0         5.2          2.0         "virginica"
6.2          3.4         5.4          2.3         "virginica"
5.9          3.0         5.1          1.8         "virginica"

Main> groupby(OnAll(mean, std), iris, :Species, select = Not(:Species))

Table with 3 rows, 9 columns:
Species       SepalLength_mean  SepalWidth_mean  PetalLength_mean  PetalWidth_mean  SepalLength_std  SepalWidth_std  PetalLength_std  PetalWidth_std
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
"setosa"      5.006             3.418            1.464             0.244            0.35249          0.381024        0.173511         0.10721
"versicolor"  5.936             2.77             4.26              1.326            0.516171         0.313798        0.469911         0.197753
"virginica"   6.588             2.974            5.552             2.026            0.63588          0.322497        0.551895         0.27465
```

I still have to add docstrings and tests. I have a very strange bug in the REPL though (the above works in the VS Code extension). In the REPL with the exact same code I get:

```julia
julia> groupby(OnAll(mean, std), iris, :Species, select = Not(:Species))
Table with 3 rows, 9 columns:
Columns:
#  colname           type
────────────────────────────
1  Species           String
2  SepalLength_mean  Float64
3  SepalWidth_mean   Float64
4  PetalLength_mean  Float64
5  PetalWidth_mean   Float64
6  SepalLength_std   Float64
7  SepalWidth_std    Float64
8  PetalLength_std   Float64
9  PetalWidth_std    Float64
```

which really doesn't make a lot of sense to me. Any idea what is going on?