### PR TITLE
Summarize all columns (second try)

### DIFF
--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -408,7 +408,10 @@ ApplyColwise(t::NamedTuple) = ApplyColwise(Tuple(values(t)), Tuple(keys(t)))
 init_func(ac::ApplyColwise, t::AbstractVector) =
     Tuple(Symbol(n) => f for (f, n) in zip(ac.functions, ac.names))
 
-init_func(ac::ApplyColwise, t::Union{AbstractIndexedTable, Columns}) =
+init_func(ac::ApplyColwise, t::Union{AbstractIndexedTable, Columns}) = _init_func(ac::ApplyColwise, t)
+
+# small refactor to avoid code duplication in JuliaDB:
+_init_func(ac::ApplyColwise, t) = 
     Tuple(Symbol(s, :_, n) => s => f for s in colnames(t), (f, n) in zip(ac.functions, ac.names))
 
 """

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -1,4 +1,4 @@
-export dropna, selectkeys, selectvalues, Not, Keys
+export dropna, selectkeys, selectvalues
 
 """
 `select(t::Table, which::Selection)`
@@ -142,22 +142,6 @@ end
 
 function selectvalues(x::NDSparse, which; kwargs...)
     ndsparse(keys(x), rows(values(x), which); kwargs...)
-end
-
-struct Not{T}
-    names::T
-end
-
-Not(args...) = Not(args)
-
-for f in [:(Base.select), :columns, :rows, :excludecols]
-    @eval $f(t::AbstractIndexedTable, not::Not) = $f(t, excludecols(t, not.names))
-end
-
-struct Keys; end
-
-for f in [:(Base.select), :columns, :rows, :excludecols]
-    @eval $f(t::AbstractIndexedTable, keys::Keys) = $f(t, pkeynames(t))
 end
 
 """

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -1,4 +1,4 @@
-export dropna, selectkeys, selectvalues, ApplyColwise, Not, Keys
+export dropna, selectkeys, selectvalues, Not, Keys
 
 """
 `select(t::Table, which::Selection)`
@@ -143,23 +143,6 @@ end
 function selectvalues(x::NDSparse, which; kwargs...)
     ndsparse(keys(x), rows(values(x), which); kwargs...)
 end
-
-struct ApplyColwise{N, T<:Tuple}
-    functions::T
-    names::NTuple{N, Symbol}
-end
-
-ApplyColwise(args...) = ApplyColwise(args)
-ApplyColwise(t::Tuple) = ApplyColwise(t, map(Symbol,t))
-
-function (ac::ApplyColwise)(t::Union{AbstractIndexedTable, Columns})
-    func = Tuple(Symbol(s, :_, n) => s => f for s in colnames(t),
-        (f, n) in zip(ac.functions, ac.names))
-    fs, input, S = init_inputs(func, t, reduced_type, true)
-    _apply(fs, fs isa Tup ? columns(input) : input)
-end
-
-(ac::ApplyColwise)(t) = (ac::ApplyColwise)(convert(Columns, t))
 
 struct Not{T}
     names::T

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -828,14 +828,16 @@ end
                         NDSparse([1, 1], [2, 3], Columns(maxv=[4, 5], minv=[1, 0]))
 end
 
-@testset "colwise" begin
+@testset "summarize" begin
     a = table([1,3,5], [2,2,2], names = [:x, :y])
-    @test ApplyColwise(mean, std)(a) ==
+    @test summarize((mean, std), a) ==
         @NT(x_mean = 3.0, y_mean = 2.0, x_std = 2.0, y_std = 0.0)
-    @test ApplyColwise(mean, std)(collect(a)) == ApplyColwise(mean, std)(a)
-    @test ApplyColwise(mean, std)([1,2,3]) == @NT(mean = 2.0, std = 1.0)
-    @test ApplyColwise((mean, std), (:m, :s))(a) ==
+    @test summarize((mean, std), a, select = :x) == @NT(mean = 3.0, std = 2.0)
+    @test summarize(@NT(m = mean, s = std), a) ==
         @NT(x_m = 3.0, y_m = 2.0, x_s = 2.0, y_s = 0.0)
+    b = table(["a","a","b","b"], [1,3,5,7], [2,2,2,2], names = [:x, :y, :z], pkey = :x)
+    @test summarize(mean, b) ==
+        table(["a","b"], [2.0,6.0], [2.0,2.0], names = [:x, :y_mean, :z_mean], pkey = :x)
 end
 
 @testset "select" begin

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -828,6 +828,16 @@ end
                         NDSparse([1, 1], [2, 3], Columns(maxv=[4, 5], minv=[1, 0]))
 end
 
+@testset "colwise" begin
+    a = table([1,3,5], [2,2,2], names = [:x, :y])
+    @test ApplyColwise(mean, std)(a) ==
+        @NT(x_mean = 3.0, y_mean = 2.0, x_std = 2.0, y_std = 0.0)
+    @test ApplyColwise(mean, std)(collect(a)) == ApplyColwise(mean, std)(a)
+    @test ApplyColwise(mean, std)([1,2,3]) == @NT(mean = 2.0, std = 1.0)
+    @test ApplyColwise((mean, std), (:m, :s))(a) ==
+        @NT(x_m = 3.0, y_m = 2.0, x_s = 2.0, y_s = 0.0)
+end
+
 @testset "select" begin
     a = table([12,21,32], [52,41,34], [11,53,150], pkey=[1,2])
     b = table([12,23,32], [52,43,34], [56,13,10], pkey=[1,2])


### PR DESCRIPTION
I've tried a different implementation of #109 where I add a separate function `summarize`, that corresponds to dplyr's `summarise_each` and DataFrames' `aggregate`. It uses the usual `by`, `select` mechanism: see docstrings and tests for example usage.