### PR TITLE
add missing init_func method

### DIFF
--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -406,6 +406,7 @@ ApplyColwise(f) = ApplyColwise(f, Symbol[])
 ApplyColwise(t::Tuple) = ApplyColwise(t, [map(Symbol,t)...])
 ApplyColwise(t::NamedTuple) = ApplyColwise(Tuple(values(t)), keys(t))
 
+init_func(f, t) = f
 init_func(ac::ApplyColwise{<:Tuple}, t::AbstractVector) =
     Tuple(Symbol(n) => f for (f, n) in zip(ac.functions, ac.names))
 init_func(ac::ApplyColwise{<:Tuple}, t::Columns) =


### PR DESCRIPTION
`groupby` is calling `f = init_func(f, data)` now, but the fallback for `init_func` was missing (see discussion in #111 ).