### PR TITLE
Stack/ unstack

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -51,6 +51,7 @@ include("selection.jl")
 include("reduce.jl")
 include("flatten.jl")
 include("join.jl")
+include("reshape.jl")
 
 # TableTraits.jl integration
 include("tabletraits.jl")

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -1,7 +1,7 @@
 export stack, unstack
 
 """
-    `stack(t, by = pkeynames(t); select = excludecols(t, by), value = :value, variable = :variable)`
+    `stack(t, by = pkeynames(t); select = excludecols(t, by), variable = :variable, value = :value)`
 
 Reshape a table from the wide to the long format. Columns in `by` are kept as indexing columns.
 Columns in `select` are stacked. In addition to the id columns, two additional columns labeled `variable` and `value`
@@ -26,8 +26,8 @@ x  variable  value
 4  :xcube    64
 ```
 """
-function stack(t::NextTable, by = pkeynames(t); select = excludecols(t, by), value = :value, variable = :variable)
-    (by != pkeynames(t)) && return stack(reindex(t, by, select); value = value, variable = variable)    
+function stack(t::NextTable, by = pkeynames(t); select = excludecols(t, by), variable = :variable, value = :value)
+    (by != pkeynames(t)) && return stack(reindex(t, by, select); variable = :variable, value = :value)    
 
     valuecols = columns(t, select)
     valuecol = vec([valuecol[i] for valuecol in valuecols, i in 1:length(t)])
@@ -51,6 +51,41 @@ function unstack(::Type{T}, key, val, cols) where {T}
     convert(NextTable, key, dest_val)
 end
 
+"""
+    `unstack(t, by = pkeynames(t); variable = :variable, value = :value)`
+
+Reshape a table from the long to the wide format. Columns in `by` are kept as indexing columns.
+Keyword arguments `variable` and `value` denote which column contains the column identifier and
+which the corresponding values.
+
+## Examples
+
+```jldoctest unstack
+julia> t = table(1:4, [1, 4, 9, 16], [1, 8, 27, 64], names = [:x, :xsquare, :xcube], pkey = :x);
+
+julia> long = stack(t)
+Table with 8 rows, 3 columns:
+x  variable  value
+──────────────────
+1  :xsquare  1
+1  :xcube    1
+2  :xsquare  4
+2  :xcube    8
+3  :xsquare  9
+3  :xcube    27
+4  :xsquare  16
+4  :xcube    64
+
+julia> unstack(long)
+Table with 4 rows, 3 columns:
+x  xsquare  xcube
+─────────────────
+1  1        1
+2  4        8
+3  9        27
+4  16       64
+```
+"""
 function unstack(t::NextTable, by = pkeynames(t); variable = :variable, value = :value)
     tgrp = groupby((value => identity,), t, by, select = (variable, value))
     cols = union(columns(t, variable))

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -1,7 +1,7 @@
 export stack, unstack
 
 """
-    `stack(t, by = pkeynames(t); select = excludecols(t, by), variable = :variable, value = :value)`
+`stack(t, by = pkeynames(t); select = excludecols(t, by), variable = :variable, value = :value)`
 
 Reshape a table from the wide to the long format. Columns in `by` are kept as indexing columns.
 Columns in `select` are stacked. In addition to the id columns, two additional columns labeled `variable` and `value`
@@ -29,14 +29,14 @@ x  variable  value
 function stack(t::D, by = pkeynames(t); select = isa(t, NDSparse) ? valuenames(t) : excludecols(t, by),
     variable = :variable, value = :value) where {D<:Dataset}
 
-    (by != pkeynames(t)) && return stack(reindex(t, by, select); variable = :variable, value = :value)    
+    (by != pkeynames(t)) && return stack(reindex(t, by, select); variable = :variable, value = :value)
 
     valuecols = columns(t, select)
     valuecol = [valuecol[i] for i in 1:length(t) for valuecol in valuecols]
 
     labels = fieldnames(valuecols)
     labelcol = [label for i in 1:length(t) for label in labels]
-    
+
     bycols = map(arg -> repeat(arg, inner = length(valuecols)), columns(t, by))
     convert(collectiontype(D), Columns(bycols), Columns(labelcol, valuecol, names = [variable, value]))
 end
@@ -54,7 +54,7 @@ function unstack(::Type{D}, ::Type{T}, key, val, cols) where {D <:Dataset, T}
 end
 
 """
-    `unstack(t, by = pkeynames(t); variable = :variable, value = :value)`
+`unstack(t, by = pkeynames(t); variable = :variable, value = :value)`
 
 Reshape a table from the long to the wide format. Columns in `by` are kept as indexing columns.
 Keyword arguments `variable` and `value` denote which column contains the column identifier and

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -1,12 +1,38 @@
 export stack
 
+"""
+    `stack(t, by = pkeynames(t); select = excludecols(t, by), value = :value, variable = :variable)`
+
+Reshape a table from the wide to the long format. Columns in `by` are kept as indexing columns.
+Columns in `select` are stacked. In addition to the id columns, two additional columns labeled `variable` and `value`
+are added, containg the column identifier and the stacked columns.
+
+## Examples
+
+```jldoctest stack
+julia> t = table(1:4, [1, 4, 9, 16], [1, 8, 27, 64], names = [:x, :xsquare, :xcube], pkey = :x);
+
+julia> stack(t)
+Table with 8 rows, 3 columns:
+x  variable  value
+──────────────────
+1  :xsquare  1
+1  :xcube    1
+2  :xsquare  4
+2  :xcube    8
+3  :xsquare  9
+3  :xcube    27
+4  :xsquare  16
+4  :xcube    64
+```
+"""
 function stack(t::NextTable, by = pkeynames(t); select = excludecols(t, by), value = :value, variable = :variable)
     (by != pkeynames(t)) && return stack(reindex(t, by, select); value = value, variable = variable)    
-    
+
     valuecols = columns(t, select)
     valuecol = vec([valuecol[i] for valuecol in valuecols, i in 1:length(t)])
 
-    labels = keys(valuecols)
+    labels = fieldnames(valuecols)
     labelcol = vec([label for label in labels, i in 1:length(t)])
     
     bycols = map(arg -> repeat(arg, inner = length(valuecols)), columns(t, by))

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -30,10 +30,10 @@ function stack(t::NextTable, by = pkeynames(t); select = excludecols(t, by), var
     (by != pkeynames(t)) && return stack(reindex(t, by, select); variable = :variable, value = :value)    
 
     valuecols = columns(t, select)
-    valuecol = vec([valuecol[i] for valuecol in valuecols, i in 1:length(t)])
+    valuecol = [valuecol[i] for i in 1:length(t) for valuecol in valuecols]
 
     labels = fieldnames(valuecols)
-    labelcol = vec([label for label in labels, i in 1:length(t)])
+    labelcol = [label for i in 1:length(t) for label in labels]
     
     bycols = map(arg -> repeat(arg, inner = length(valuecols)), columns(t, by))
     convert(NextTable, Columns(bycols), Columns(labelcol, valuecol, names = [variable, value]))

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -1,0 +1,14 @@
+export stack
+
+function stack(t::NextTable, by = pkeynames(t); select = excludecols(t, by), value = :value, variable = :variable)
+    (by != pkeynames(t)) && return stack(reindex(t, by, select); value = value, variable = variable)    
+    
+    valuecols = columns(t, select)
+    valuecol = vec([valuecol[i] for valuecol in valuecols, i in 1:length(t)])
+
+    labels = keys(valuecols)
+    labelcol = vec([label for label in labels, i in 1:length(t)])
+    
+    bycols = map(arg -> repeat(arg, inner = length(valuecols)), columns(t, by))
+    convert(NextTable, Columns(bycols), Columns(labelcol, valuecol, names = [variable, value]))
+end

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -26,7 +26,9 @@ x  variable  value
 4  :xcube    64
 ```
 """
-function stack(t::NextTable, by = pkeynames(t); select = excludecols(t, by), variable = :variable, value = :value)
+function stack(t::D, by = pkeynames(t); select = isa(t, NDSparse) ? valuenames(t) : excludecols(t, by),
+    variable = :variable, value = :value) where {D<:Dataset}
+
     (by != pkeynames(t)) && return stack(reindex(t, by, select); variable = :variable, value = :value)    
 
     valuecols = columns(t, select)
@@ -36,10 +38,10 @@ function stack(t::NextTable, by = pkeynames(t); select = excludecols(t, by), var
     labelcol = [label for i in 1:length(t) for label in labels]
     
     bycols = map(arg -> repeat(arg, inner = length(valuecols)), columns(t, by))
-    convert(NextTable, Columns(bycols), Columns(labelcol, valuecol, names = [variable, value]))
+    convert(collectiontype(D), Columns(bycols), Columns(labelcol, valuecol, names = [variable, value]))
 end
 
-function unstack(::Type{T}, key, val, cols) where {T}
+function unstack(::Type{D}, ::Type{T}, key, val, cols) where {D <:Dataset, T}
     dest_val = Columns((DataValues.DataValueArray{T}(length(val)) for i in cols)...; names = cols)
     for (i, el) in enumerate(val)
         for j in el
@@ -48,7 +50,7 @@ function unstack(::Type{T}, key, val, cols) where {T}
             columns(dest_val, k)[i] = v
         end
     end
-    convert(NextTable, key, dest_val)
+    convert(collectiontype(D), key, dest_val)
 end
 
 """
@@ -86,9 +88,9 @@ x  xsquare  xcube
 4  16       64
 ```
 """
-function unstack(t::NextTable, by = pkeynames(t); variable = :variable, value = :value)
+function unstack(t::D, by = pkeynames(t); variable = :variable, value = :value) where {D<:Dataset}
     tgrp = groupby((value => identity,), t, by, select = (variable, value))
     cols = union(columns(t, variable))
     T = eltype(columns(t, value))
-    unstack(T isa Type{<:DataValue} ? eltype(T) : T, pkeys(tgrp), columns(tgrp, value), cols)
+    unstack(D, T isa Type{<:DataValue} ? eltype(T) : T, pkeys(tgrp), columns(tgrp, value), cols)
 end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -842,12 +842,16 @@ end
 
 @testset "reshape" begin
     t = table(1:4, [1, 4, 9, 16], [1, 8, 27, 64], names = [:x, :xsquare, :xcube], pkey = :x)
-    wide = stack(t; variable = :var, value = :val)
-    @test wide == table([1, 1, 2, 2, 3, 3, 4, 4],
+    tsparse = IndexedTables._convert(NDSparse, t)
+    long = stack(t; variable = :var, value = :val)
+    longsparse = stack(tsparse; variable = :var, value = :val)
+    @test long == table([1, 1, 2, 2, 3, 3, 4, 4],
                         [:xsquare, :xcube, :xsquare, :xcube, :xsquare, :xcube, :xsquare, :xcube],
                         [1, 1, 4, 8, 9, 27, 16, 64];
                         names = [:x, :var, :val], pkey = :x)
-    @test unstack(wide; variable = :var, value = :val) == t
+    @test longsparse == IndexedTables._convert(NDSparse, long)
+    @test unstack(long; variable = :var, value = :val) == t
+    @test unstack(longsparse; variable = :var, value = :val) == tsparse
     t1 = table([1, 1, 1, 2, 2], [:x, :x, :y, :x, :y], [1, 2, 3, 4, 5], names = [:x, :variable, :value])
     @test_throws Exception unstack(t1, :x)
 end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -950,6 +950,11 @@ end
     @test groupby(identity, t, (:x, :y), select=:z, flatten = true).pkey == [1,2]
 end
 
+@testset "stack" begin
+    
+
+end
+
 @testset "ColDict" begin
     t = table([1], names=[:x1])
     d = ColDict(t)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -840,6 +840,18 @@ end
         table(["a","b"], [2.0,6.0], [2.0,2.0], names = [:x, :y, :z], pkey = :x)
 end
 
+@testset "reshape" begin
+    t = table(1:4, [1, 4, 9, 16], [1, 8, 27, 64], names = [:x, :xsquare, :xcube], pkey = :x)
+    wide = stack(t; variable = :var, value = :val)
+    @test wide == table([1, 1, 2, 2, 3, 3, 4, 4],
+                        [:xsquare, :xcube, :xsquare, :xcube, :xsquare, :xcube, :xsquare, :xcube],
+                        [1, 1, 4, 8, 9, 27, 16, 64];
+                        names = [:x, :var, :val], pkey = :x)
+    @test unstack(wide; variable = :var, value = :val) == t
+    t1 = table([1, 1, 1, 2, 2], [:x, :x, :y, :x, :y], [1, 2, 3, 4, 5], names = [:x, :variable, :value])
+    @test_throws Exception unstack(t1, :x)
+end
+
 @testset "select" begin
     a = table([12,21,32], [52,41,34], [11,53,150], pkey=[1,2])
     b = table([12,23,32], [52,43,34], [56,13,10], pkey=[1,2])
@@ -948,11 +960,6 @@ end
     t=table([1,1,1,2,2,2], [1,1,2,1,1,2], [1,2,3,4,5,6], names=[:x,:y,:z], pkey=[1,2]);
     @test groupby(identity, t, (:x, :y), select=:z, flatten = true) == renamecol(t, :z, :identity)
     @test groupby(identity, t, (:x, :y), select=:z, flatten = true).pkey == [1,2]
-end
-
-@testset "stack" begin
-    
-
 end
 
 @testset "ColDict" begin


### PR DESCRIPTION
I've implemented `stack` and `unstack` for `NextTable` and `NDSparse` to change data from `wide` to `long` format and viceversa. In `stack` you choose the indexing columns with `by` and you select columns to stack with `select`.  Optional `variable` and `value` allow to choose name of column of identifiers and column of values. In `unstack`, you choose the indexing columns with `by` and you choose the column of identifiers and column of values with `variable` and `value` respectively (I tried to be as consistent as possible with DataFrames.

Example:

```julia
julia> iris
Table with 150 rows, 5 columns:
SepalLength  SepalWidth  PetalLength  PetalWidth  Species
─────────────────────────────────────────────────────────────
5.1          3.5         1.4          0.2         "setosa"
4.9          3.0         1.4          0.2         "setosa"
4.7          3.2         1.3          0.2         "setosa"
4.6          3.1         1.5          0.2         "setosa"
5.0          3.6         1.4          0.2         "setosa"
5.4          3.9         1.7          0.4         "setosa"
4.6          3.4         1.4          0.3         "setosa"
5.0          3.4         1.5          0.2         "setosa"
⋮
6.7          3.3         5.7          2.5         "virginica"
6.7          3.0         5.2          2.3         "virginica"
6.3          2.5         5.0          1.9         "virginica"
6.5          3.0         5.2          2.0         "virginica"
6.2          3.4         5.4          2.3         "virginica"
5.9          3.0         5.1          1.8         "virginica"

julia> stack(iris, :Species)
Table with 600 rows, 3 columns:
Species      variable      value
────────────────────────────────
"setosa"     :SepalLength  5.1
"setosa"     :SepalWidth   3.5
"setosa"     :PetalLength  1.4
"setosa"     :PetalWidth   0.2
"setosa"     :SepalLength  4.9
"setosa"     :SepalWidth   3.0
"setosa"     :PetalLength  1.4
"setosa"     :PetalWidth   0.2
⋮
"virginica"  :PetalLength  5.4
"virginica"  :PetalWidth   2.3
"virginica"  :SepalLength  5.9
"virginica"  :SepalWidth   3.0
"virginica"  :PetalLength  5.1
"virginica"  :PetalWidth   1.8
```