### PR TITLE
WIP/RFC: added SpecialSelector

### DIFF
--- a/src/columns.jl
+++ b/src/columns.jl
@@ -440,6 +440,7 @@ end
 
 const SpecialSelector = Union{Not, Join, Keys, Between, Function}
 
+lowerselection(t, s)                     = s
 lowerselection(t, s::Union{Int, Symbol}) = colindex(t, s)
 lowerselection(t, s::Tuple)              = map(x -> lowerselection(t, x), s)
 lowerselection(t, s::Join)               = Tuple(union((lowerselection(t, x) for x in s.cols)...))

--- a/src/table.jl
+++ b/src/table.jl
@@ -345,6 +345,10 @@ function Base.getindex(d::ColDict{<:AbstractIndexedTable}, key::Tuple)
     table(d.src, columns=columns(t, key), pkey=pkey)
 end
 
+function Base.getindex(d::ColDict{<:AbstractIndexedTable}, key::SpecialSelector)
+    getindex(d, lowerselection(d[], key))
+end
+
 function ColDict(t::AbstractIndexedTable; copy=nothing)
     ColDict(Base.copy(t.pkey), t,
             Base.copy(colnames(t)), Any[columns(t)...], copy)
@@ -584,7 +588,7 @@ function set_show_compact!(flag=true)
 end
 
 function showtable(io::IO, t; header=nothing, cnames=colnames(t), divider=nothing, cstyle=[], full=false, ellipsis=:middle, compact=show_compact_when_wide)
-    height, width = displaysize(io) 
+    height, width = displaysize(io)
     showrows = height-5 - (header !== nothing)
     n = length(t)
     header !== nothing && println(io, header)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -383,7 +383,7 @@ end
     @test vcat(Columns(x=PooledArray(["x"])), Columns(x=["y"])) == Columns(x=["x", "y"])
 
     @test summary(c) == "5-element Columns{Tuple{Int64,Int64}}"
-   
+
 end
 
 @testset "Getindex" begin
@@ -681,6 +681,34 @@ end
     @test selectkeys(a, 2, agg=+) == ndsparse([1,2], [14,16])
 end
 
+@testset "specialselector" begin
+    t = table([1, 2, 3], ["a", "b", "c"], [4, 5, 6], names = [:x, :y, :z], pkey = :x)
+    
+    @test select(t, Keys()) == select(t, (:x,))
+    @test select(t, (Keys(), :y)) == select(t, ((:x,), :y))
+    @test select(t, Not(Keys())) == select(t, Not(:x)) == select(t, (:y, :z))
+    @test select(t, Not(Keys(), :y)) == select(t, Not(:x, :y)) == select(t, (:z,))
+    @test select(t, Join(Keys(), :y)) == select(t, (:x, :y))
+    @test select(t, Between(:x, :z)) == select(t, (:x, :y, :z))
+    @test select(t, i -> i == :y) == select(t, (:y,))
+
+    @test rows(t, Keys()) == rows(t, (:x,))
+    @test rows(t, (Keys(), :y)) == rows(t, ((:x,), :y))
+    @test rows(t, Not(Keys())) == rows(t, Not(:x)) == rows(t, (:y, :z))
+    @test rows(t, Not(Keys(), :y)) == rows(t, Not(:x, :y)) == rows(t, (:z,))
+    @test rows(t, Join(Keys(), :y)) == rows(t, (:x, :y))
+    @test rows(t, Between(:x, :z)) == rows(t, (:x, :y, :z))
+    @test rows(t, i -> i == :y) == rows(t, (:y,))
+
+    @test columns(t, Keys()) == columns(t, (:x,))
+    @test columns(t, (Keys(), :y)) == columns(t, ((:x,), :y))
+    @test columns(t, Not(Keys())) == columns(t, Not(:x)) == columns(t, (:y, :z))
+    @test columns(t, Not(Keys(), :y)) == columns(t, Not(:x, :y)) == columns(t, (:z,))
+    @test columns(t, Join(Keys(), :y)) == columns(t, (:x, :y))
+    @test columns(t, Between(:x, :z)) == columns(t, (:x, :y, :z))
+    @test columns(t, i -> i == :y) == columns(t, (:y,))
+end
+
 @testset "dropna" begin
     t = table([0.1, 0.5, NA, 0.7], [2, NA, 4, 5], [NA, 6, NA, 7], names=[:t, :x, :y])
     @test dropna(t) == table([0.7], [5], [7], names=Symbol[:t, :x, :y])
@@ -767,7 +795,7 @@ end
     @test groupreduce(+, t, :x, select=:z) == table([1, 2], [6, 15], names=Symbol[:x, :+])
     @test groupreduce(((x, y)->if x isa Int
                         @NT y = x + y
-                    else 
+                    else
                         @NT y = x.y + y
                     end), t, :x, select=:z) == table([1, 2], [6, 15], names=Symbol[:x, :y])
     @test groupreduce(:y => (+), t, :x, select=:z) == table([1, 2], [6, 15], names=Symbol[:x, :y])
@@ -903,7 +931,7 @@ end
 
     nd[1:5,1:5] = 2
     @test nd == convert(NDSparse, spdiagm(fill(2, 5)))
-   
+
 end
 
 @testset "mapslices" begin


### PR DESCRIPTION
An attempt to address #112 : if this approach is considered valid I can go on and add tests and documentation. Here I'm using as example the `hflights` dataset from [here](https://github.com/piever/JuliaDBTutorial).

```julia
julia> flights
Table with 227496 rows, 21 columns:
Columns:
#   colname            type
──────────────────────────────────────────────────
1   Year               Int64
2   Month              Int64
3   DayofMonth         Int64
4   DayOfWeek          Int64
5   DepTime            DataValues.DataValue{Int64}
6   ArrTime            DataValues.DataValue{Int64}
7   UniqueCarrier      String
8   FlightNum          Int64
9   TailNum            String
10  ActualElapsedTime  DataValues.DataValue{Int64}
11  AirTime            DataValues.DataValue{Int64}
12  ArrDelay           DataValues.DataValue{Int64}
13  DepDelay           DataValues.DataValue{Int64}
14  Origin             String
15  Dest               String
16  Distance           Int64
17  TaxiIn             DataValues.DataValue{Int64}
18  TaxiOut            DataValues.DataValue{Int64}
19  Cancelled          Int64
20  CancellationCode   String
21  Diverted           Int64

julia> select(flights, IndexedTables.Not(:Year))
Table with 227496 rows, 20 columns:
Columns:
#   colname            type
──────────────────────────────────────────────────
1   Month              Int64
2   DayofMonth         Int64
3   DayOfWeek          Int64
4   DepTime            DataValues.DataValue{Int64}
5   ArrTime            DataValues.DataValue{Int64}
6   UniqueCarrier      String
7   FlightNum          Int64
8   TailNum            String
9   ActualElapsedTime  DataValues.DataValue{Int64}
10  AirTime            DataValues.DataValue{Int64}
11  ArrDelay           DataValues.DataValue{Int64}
12  DepDelay           DataValues.DataValue{Int64}
13  Origin             String
14  Dest               String
15  Distance           Int64
16  TaxiIn             DataValues.DataValue{Int64}
17  TaxiOut            DataValues.DataValue{Int64}
18  Cancelled          Int64
19  CancellationCode   String
20  Diverted           Int64

julia> select(flights, IndexedTables.Between(:ArrTime, :Distance))
Table with 227496 rows, 11 columns:
Columns:
#   colname            type
──────────────────────────────────────────────────
1   ArrTime            DataValues.DataValue{Int64}
2   UniqueCarrier      String
3   FlightNum          Int64
4   TailNum            String
5   ActualElapsedTime  DataValues.DataValue{Int64}
6   AirTime            DataValues.DataValue{Int64}
7   ArrDelay           DataValues.DataValue{Int64}
8   DepDelay           DataValues.DataValue{Int64}
9   Origin             String
10  Dest               String
11  Distance           Int64

julia> select(flights, (IndexedTables.Not(:Year), IndexedTables.Between(:ArrTime, :Distance)))
Table with 227496 rows, 2 columns:
Columns:
#  colname  type
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
1  1        NamedTuples._NT_Month_DayofMonth_DayOfWeek_DepTime_ArrTime_UniqueCarrier_FlightNum_TailNum_ActualElapsedTime_AirTime_ArrDelay_DepDelay_Origin_Dest_Distance_TaxiIn_TaxiOut_Cancelled_CancellationCode_Diverted{Int64,Int64,Int64,DataValues.DataValue{Int64},DataValues.DataValue{Int64},String,Int64,String,DataValues.DataValue{Int64},DataValues.DataValue{Int64},DataValues.DataValue{Int64},DataValues.DataValue{Int64},String,String,Int64,DataValues.DataValue{Int64},DataValues.DataValue{Int64},Int64,String,Int64}
2  2        NamedTuples._NT_ArrTime_UniqueCarrier_FlightNum_TailNum_ActualElapsedTime_AirTime_ArrDelay_DepDelay_Origin_Dest_Distance{DataValues.DataValue{Int64},String,Int64,String,DataValues.DataValue{Int64},DataValues.DataValue{Int64},DataValues.DataValue{Int64},DataValues.DataValue{Int64},String,String,Int64}
```

The new selectors should be compatible with `columns` and `rows` as well.

Overall I'm adding as special selectors:

1. `Not`, to exclude a set of columns (potentially selected using other special selectors)
1. `Keys` to select the primary keys
1. `Between` to select a range of columns
1. `Join` to select the union of a set of special selectors
1. If you select with a function, it will use that function to filter names of the columns, for example `select(flights, i -> contains(String(i), "Delay"))`

Also, sorry about the noise in the diff: 3 lines appear changed but are not, I'm afraid Atom removed some white space at the end of the line.

