### PR TITLE
groupby revamped: column views and using key values

### DIFF
--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -250,20 +250,25 @@ end
 
 ## GroupBy
 
+_apply_with_key(f::Tup, data::Tup, process_data) = _apply(f, map(process_data, data))
+_apply_with_key(f::Tup, data, process_data) = _apply_with_key(f::Tup, columns(data), process_data)
+_apply_with_key(f, data, process_data) = _apply(f, process_data(data))
+
+_apply_with_key(f::Tup, key, data, process_data) = _apply_with_key(f, key, columns(data), process_data)
+_apply_with_key(f::Tup, key, data::Tup, process_data) = _apply(f, map(t->key, data), map(process_data, data))
+_apply_with_key(f, key, data, process_data) = _apply(f, key, process_cs(data))
+
 function _groupby(f, key, data, perm, dest_key=similar(key,0),
-                  dest_data=nothing, i1=1)
+                  dest_data=nothing, i1=1; usekey = false)
     n = length(key)
-    cs = f isa Tup ? columns(data) : data
     while i1 <= n
         i = i1+1
         while i <= n && roweq(key, perm[i], perm[i1])
             i += 1
         end
-        if isa(cs, Tup)
-            val = _apply(f, map(t -> view(t, perm[i1:(i-1)]), cs))
-        else
-            val = _apply(f, view(cs, perm[i1:(i-1)]))
-        end
+        process_data = t -> view(t, perm[i1:(i-1)])
+        val = usekey ? _apply_with_key(f, key[perm[i1]], data, process_data) :
+                       _apply_with_key(f, data, process_data)
 
         push!(dest_key, key[perm[i1]])
         if dest_data === nothing
@@ -369,7 +374,11 @@ x  normy
 
 """
 function groupby end
-function groupby(f, t::Dataset, by=pkeynames(t); select=valuenames(t), flatten=false)
+
+# t isa AbstractIndexedTable ? Not(by) :
+function groupby(f, t::Dataset, by=pkeynames(t);
+    select = valuenames(t), flatten=false, usekey = false)
+
     data = rows(t, select)
     f = init_func(f, data)
     # we want to try and keep the column names
@@ -385,13 +394,13 @@ function groupby(f, t::Dataset, by=pkeynames(t); select=valuenames(t), flatten=f
 
     fs, input, S = init_inputs(f, data, reduced_type, true)
 
-    by == () && return _apply(fs, fs isa Tup ? columns(input) : input)
+    by == () && return usekey ? _apply_with_key(fs, (), input, identity) : _apply_with_key(fs, input, identity)
 
     key  = rows(t, by)
 
     perm = sortpermby(t, by)
     # Note: we're not using S here, we'll let _groupby figure it out
-    dest_key, dest_data = _groupby(fs, key, input, perm)
+    dest_key, dest_data = _groupby(fs, key, input, perm; usekey = usekey)
 
     t = convert(collectiontype(t), dest_key, dest_data, presorted=true, copy=false)
     t isa NextTable && flatten ?

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -251,11 +251,11 @@ end
 ## GroupBy
 
 _apply_with_key(f::Tup, data::Tup, process_data) = _apply(f, map(process_data, data))
-_apply_with_key(f::Tup, data, process_data) = _apply_with_key(f::Tup, columns(data), process_data)
+_apply_with_key(f::Tup, data, process_data) = _apply_with_key(f, columns(data), process_data)
 _apply_with_key(f, data, process_data) = _apply(f, process_data(data))
 
-_apply_with_key(f::Tup, key, data, process_data) = _apply_with_key(f, key, columns(data), process_data)
 _apply_with_key(f::Tup, key, data::Tup, process_data) = _apply(f, map(t->key, data), map(process_data, data))
+_apply_with_key(f::Tup, key, data, process_data) = _apply_with_key(f, key, columns(data), process_data)
 _apply_with_key(f, key, data, process_data) = _apply(f, key, process_cs(data))
 
 function _groupby(f, key, data, perm, dest_key=similar(key,0),
@@ -375,9 +375,8 @@ x  normy
 """
 function groupby end
 
-# t isa AbstractIndexedTable ? Not(by) :
 function groupby(f, t::Dataset, by=pkeynames(t);
-    select = valuenames(t), flatten=false, usekey = false)
+    select = t isa AbstractIndexedTable ? Not(by) : valuenames(t), flatten=false, usekey = false)
 
     data = rows(t, select)
     f = init_func(f, data)

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -256,7 +256,7 @@ _apply_with_key(f, data, process_data) = _apply(f, process_data(data))
 
 _apply_with_key(f::Tup, key, data::Tup, process_data) = _apply(f, map(t->key, data), map(process_data, data))
 _apply_with_key(f::Tup, key, data, process_data) = _apply_with_key(f, key, columns(data), process_data)
-_apply_with_key(f, key, data, process_data) = _apply(f, key, process_cs(data))
+_apply_with_key(f, key, data, process_data) = _apply(f, key, process_data(data))
 
 function _groupby(f, key, data, perm, dest_key=similar(key,0),
                   dest_data=nothing, i1=1; usekey = false)
@@ -276,7 +276,7 @@ function _groupby(f, key, data, perm, dest_key=similar(key,0),
             if isa(val, Tup)
                 newdata = convert(Columns, newdata)
             end
-            return _groupby(f, key, data, perm, dest_key, newdata, i)
+            return _groupby(f, key, data, perm, dest_key, newdata, i; usekey = usekey)
         else
             push!(dest_data, val)
         end
@@ -370,6 +370,21 @@ x  normy
 1  3.5
 2  5.5
 2  5.5
+```
+
+The keyword option `usekey = true` allows to use information from the indexing column. `f` will need to accept two
+arguments, the first being the key (as a `Tuple` or `NamedTuple`) the second the data (as `Columns`).
+
+```jldoctest
+julia> t = table([1,1,2,2], [3,4,5,6], names=[:x,:y])
+
+julia> groupby((:x_plus_mean_y => (key, d) -> key.x + mean(d),),
+                              t, :x, select=:y, usekey = true)
+Table with 2 rows, 2 columns:
+x  x_plus_mean_y
+────────────────
+1  4.5
+2  7.5
 ```
 
 """

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -683,7 +683,7 @@ end
 
 @testset "specialselector" begin
     t = table([1, 2, 3], ["a", "b", "c"], [4, 5, 6], names = [:x, :y, :z], pkey = :x)
-    
+
     @test select(t, Keys()) == select(t, (:x,))
     @test select(t, (Keys(), :y)) == select(t, ((:x,), :y))
     @test select(t, Not(Keys())) == select(t, Not(:x)) == select(t, (:y, :z))
@@ -832,6 +832,11 @@ end
     @test groupby((mean, std, var), t, :y, select=:z) == table([1, 2], [3.5, 3.5], [2.3804761428476167, 0.7071067811865476], [5.666666666666667, 0.5], names=Symbol[:y, :mean, :std, :var])
     @test groupby(@NT(q25 = (z->quantile(z, 0.25)), q50 = median, q75 = (z->quantile(z, 0.75))), t, :y, select=:z) == table([1, 2], [1.75, 3.25], [3.5, 3.5], [5.25, 3.75], names=Symbol[:y, :q25, :q50, :q75])
     @test groupby(@NT(xmean = (:z => mean), ystd = ((:y => (-)) => std)), t, :x) == table([1, 2], [2.0, 5.0], [0.5773502691896257, 0.5773502691896257], names=Symbol[:x, :xmean, :ystd])
+    @test groupby(@NT(ncols = length∘colnames), t, :x) == table([1, 2], [2, 2], names = [:x, :ncols], pkey = :x)
+    func1 = (key, dd) -> key.x + length(dd)
+    @test groupby((:s => func1, ), t, :x, usekey = true) == table([1, 2], [4, 5], names = [:x, :s], pkey = :x)
+    func2 = (key, dd) -> key.x - length(dd)
+    @test groupby((:s => func1, :d => func2), t, :x, usekey = true) == table([1, 2], [4, 5], [-2, -1], names = [:x, :s, :d], pkey = :x)
 
     @test groupby(maximum,
                   NDSparse([1, 1, 1, 1, 1, 1],


### PR DESCRIPTION
This packages implements already a `view` on `Columns`: it simply makes a new `Columns` object whose columns are views of the parent columns. I think this is what should be passed to `groupby`. Now it is much easier to select columns from this object.

For example:

```julia
julia> t = table(@NT(a = [1, 1, 2, 2], b = rand(4), c = rand(4)))
Table with 4 rows, 3 columns:
a  b           c
───────────────────────
1  0.00334594  0.195242
1  0.390544    0.612741
2  0.923973    0.243861
2  0.630879    0.795554

julia> groupby(t, :a) do dd
           mean(column(dd, :b).-column(dd, :c))
       end
Table with 2 rows, 2 columns:
a  #3
────────────
1  -0.207046
2  0.257718
```

In a later issue we should discuss whether we can also allow the user to use values from `key` rather than `data` [here](https://github.com/JuliaComputing/IndexedTables.jl/blob/master/src/reduce.jl#L259). For example Query allows you to do that with a special syntax `g.key`.

I didn't really understand the `SubArrayClosure` hack or whether it is required, but if it is I can simply do a `ViewClosure` type and recreate it.