### PR TITLE
fix  #124 : automatic naming for usekey = true

### DIFF
--- a/src/columns.jl
+++ b/src/columns.jl
@@ -1101,8 +1101,10 @@ using OnlineStats
 
 # Initialize type of output, functions to apply, input and output vectors
 
-function reduced_type(f, x, isvec)
-    if isvec
+function reduced_type(f, x, isvec, key = nothing)
+    if key !== nothing
+        _promote_op(f, eltype(key), typeof(x))
+    elseif isvec
         _promote_op(f, typeof(x))
     else
         _promote_op((a,b)->_apply(f, init_first(f, a), b),

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -402,10 +402,11 @@ function groupby(f, t::Dataset, by=pkeynames(t);
         by = (by,)
     end
 
+    key = by == () ? fill((), length(t)) : rows(t, by)
     # we want to try and keep the column names
     if typeof(t)<:NextTable &&
         !isa(f, Tup) &&
-        !(reduced_type(f, data, true, usekey ? rows(t, by) : nothing) <: Tup)
+        !(reduced_type(f, data, true, usekey ? key : nothing) <: Tup)
         # Name the result after the function
         return groupby((f,), t, by, select=select, flatten=flatten, usekey = usekey)
     end
@@ -413,8 +414,6 @@ function groupby(f, t::Dataset, by=pkeynames(t);
     fs, input, S = init_inputs(f, data, reduced_type, true)
 
     by == () && return usekey ? _apply_with_key(fs, (), input, identity) : _apply_with_key(fs, input, identity)
-
-    key  = rows(t, by)
 
     perm = sortpermby(t, by)
     # Note: we're not using S here, we'll let _groupby figure it out

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -398,16 +398,16 @@ function groupby(f, t::Dataset, by=pkeynames(t);
 
     data = rows(t, select)
     f = init_func(f, data)
+    if !(by isa Tuple)
+        by = (by,)
+    end
 
     # we want to try and keep the column names
     if typeof(t)<:NextTable &&
         !isa(f, Tup) &&
-        !(reduced_type(f, data, true) <: Tup)
+        !(reduced_type(f, data, true, usekey ? rows(t, by) : nothing) <: Tup)
         # Name the result after the function
-        return groupby((f,), t, by, select=select, flatten=flatten)
-    end
-    if !(by isa Tuple)
-        by = (by,)
+        return groupby((f,), t, by, select=select, flatten=flatten, usekey = usekey)
     end
 
     fs, input, S = init_inputs(f, data, reduced_type, true)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -842,6 +842,8 @@ end
     @test groupby((:s => func1, :d => func2), t, :x, usekey = true) == table([1, 2], [4, 5], [-2, -1], names = [:x, :s, :d], pkey = :x)
     s(key, dd) = func1(key, dd)
     @test groupby(s, t, :x, usekey = true) == groupby((:s => func1, ), t, :x, usekey = true)
+    s2(key, dd) = length(dd)
+    @test groupby(s2, t, usekey = true) == @NT(s2 = 6)
 
     @test groupby(maximum,
                   NDSparse([1, 1, 1, 1, 1, 1],

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -840,6 +840,8 @@ end
     @test groupby((:s => func1, ), t, :x, usekey = true) == table([1, 2], [4, 5], names = [:x, :s], pkey = :x)
     func2 = (key, dd) -> key.x - length(dd)
     @test groupby((:s => func1, :d => func2), t, :x, usekey = true) == table([1, 2], [4, 5], [-2, -1], names = [:x, :s, :d], pkey = :x)
+    s(key, dd) = func1(key, dd)
+    @test groupby(s, t, :x, usekey = true) == groupby((:s => func1, ), t, :x, usekey = true)
 
     @test groupby(maximum,
                   NDSparse([1, 1, 1, 1, 1, 1],


### PR DESCRIPTION
I hadn't updated `reduced_type` to work with `usekey` so a step of the naming process was failing.