### PR TITLE
allow setindex! on arrays with shared data

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -210,6 +210,13 @@ function flush!(t::NDSparse)
         # 1. form sorted array of temp values, preferring values added later (`right`)
         temp = NDSparse(t.index_buffer, t.data_buffer, copy=false, agg=right)
 
+        if any(isshared, _cols_tuple(keys(t)))
+            t.index = copy(keys(t))
+        end
+        if any(isshared, _cols_tuple(values(t)))
+            t.data = copy(values(t))
+        end
+
         # 2. merge in
         _merge!(t, temp, right)
 

--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -2,7 +2,7 @@ export AbstractNDSparse, NDSparse, ndsparse
 
 abstract type AbstractNDSparse end
 
-struct NDSparse{T, D<:Tuple, C<:Columns, V<:AbstractVector} <: AbstractNDSparse
+mutable struct NDSparse{T, D<:Tuple, C<:Columns, V<:AbstractVector} <: AbstractNDSparse
     index::C
     data::V
     _table::NextTable

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -356,3 +356,18 @@ end
 Base.@pure function concat_tup_type(T::Type, S::Type)
     Tuple{T,S}
 end
+
+# check to see if array has shared data
+# used in flush! to create a copy of the arrays
+function isshared(x)
+    try
+        resize!(x, length(x))
+        false
+    catch err
+        if err isa ErrorException && err.msg == "cannot resize array with shared data"
+            return true
+        else
+            rethrow(err)
+        end
+    end
+end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -1020,3 +1020,11 @@ end
     d[:x3] = :x2 => -
     @test d[] == table([1], [2], [-2], names=[:x1,:x2,:x3])
 end
+
+@testset "shared data setindex!" begin
+    x = ndsparse(([1,2], [3,4]), [5,6])
+    reinterpret(UInt8, columns(x)[1]) # set isshared flag
+    x[3,4] = 7
+    flush!(x)
+    @test x == ndsparse(([1,2,3],[3,4,4]), [5,6,7])
+end


### PR DESCRIPTION
This is a hack to detect if a buffer is shared. If it is it copies the NDSparse and then does flush!.