### PR TITLE
Fix #131: allow special selectors everywhere

### DIFF
--- a/src/join.jl
+++ b/src/join.jl
@@ -407,7 +407,8 @@ function Base.join(f, left::Dataset, right::Dataset;
     if !(how in [:inner, :left, :outer, :anti])
         error("Invalid how: supported join types are :inner, :left, :outer, and :anti")
     end
-
+    lkey = lowerselection(left, lkey)
+    rkey = lowerselection(right, rkey)
     lperm = sortpermby(left, lkey; cache=cache)
     rperm = sortpermby(right, rkey; cache=cache)
     if !isa(lkey, Tuple)
@@ -418,6 +419,8 @@ function Base.join(f, left::Dataset, right::Dataset;
         rkey = (rkey,)
     end
 
+    lselect = lowerselection(left, lselect)
+    rselect = lowerselection(right, rselect)
     if f === concat_tup
         if !isa(lselect, Tuple)
             lselect = (lselect,)
@@ -559,7 +562,7 @@ a  b  groups
 
 # Outer join
 
-Outer (aka Union) join looks up rows from `right` where keys match that in `left`, and also rows from `left` where keys match those in `left`, if there are no matches on either side, a tuple of NA values is used. The output is guarranteed to contain 
+Outer (aka Union) join looks up rows from `right` where keys match that in `left`, and also rows from `left` where keys match those in `left`, if there are no matches on either side, a tuple of NA values is used. The output is guarranteed to contain
 
 ```jldoctest groupjoin
 

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -233,6 +233,7 @@ function groupreduce(f, t::Dataset, by=pkeynames(t);
         # Name the result after the function
         return groupreduce((f,), t, by, select=select)
     end
+    by = lowerselection(t, by)
     if !isa(by, Tuple)
         by=(by,)
     end
@@ -398,6 +399,7 @@ function groupby(f, t::Dataset, by=pkeynames(t);
 
     data = rows(t, select)
     f = init_func(f, data)
+    by = lowerselection(t, by)
     if !(by isa Tuple)
         by = (by,)
     end

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -181,11 +181,17 @@ julia> pkeynames(t)
 function reindex end
 
 function reindex(T::Type, t, by, select; kwargs...)
+    if isa(by, SpecialSelector)
+        return reindex(T, t, lowerselection(t, by), select; kwargs...)
+    end
     if !isa(by, Tuple)
         return reindex(T, t, (by,), select; kwargs...)
     end
     if T <: NextTable && !isa(select, Tuple)
         return reindex(T, t, by, (select,); kwargs...)
+    end
+    if T <: NextTable && isa(select, SpecialSelector)
+        return reindex(T, t, by, lowerselection(t, select); kwargs...)
     end
     perm = sortpermby(t, by)
     if isa(perm, Base.OneTo)

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -187,11 +187,8 @@ function reindex(T::Type, t, by, select; kwargs...)
     if !isa(by, Tuple)
         return reindex(T, t, (by,), select; kwargs...)
     end
-    if T <: NextTable && !isa(select, Tuple)
+    if T <: NextTable && !isa(select, Tuple) && !isa(select, SpecialSelector)
         return reindex(T, t, by, (select,); kwargs...)
-    end
-    if T <: NextTable && isa(select, SpecialSelector)
-        return reindex(T, t, by, lowerselection(t, select); kwargs...)
     end
     perm = sortpermby(t, by)
     if isa(perm, Base.OneTo)

--- a/src/table.jl
+++ b/src/table.jl
@@ -541,6 +541,9 @@ julia> excludecols([1,2,3], (1,))
 ```
 """
 function excludecols(t, cols)
+    if cols isa SpecialSelector
+        return excludecols(t, lowerselection(t, cols))
+    end
     if !isa(cols, Tuple)
         return excludecols(t, (cols,))
     end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -311,6 +311,7 @@ end
     @test pkeys(a) == Columns((["a", "b"],))
     t = table([2, 1], [1, 3], [4, 5], names=[:x, :y, :z], pkey=(1, 2))
     @test excludecols(t, (:x,)) == (2, 3)
+    @test excludecols(t, Not(2, 3)) == (2, 3)
     @test excludecols(t, (2,)) == (1, 3)
     @test excludecols(t, pkeynames(t)) == (3,)
     @test excludecols([1, 2, 3], (1,)) == ()
@@ -442,6 +443,7 @@ end
 @testset "reindex" begin
     t = table([2, 1], [1, 3], [4, 5], names=[:x, :y, :z], pkey=(1, 2))
     @test reindex(t, (:y, :z)) == table([1, 3], [4, 5], [2, 1], names=Symbol[:y, :z, :x])
+    @test reindex(t, Not(:x)) == reindex(t, (:y, :z))
     @test pkeynames(t) == (:x, :y)
     @test reindex(t, (:w => [4, 5], :z)) == table([4, 5], [5, 4], [1, 2], [3, 1], names=Symbol[:w, :z, :x, :y])
     @test pkeynames(t) == (:x, :y)
@@ -583,6 +585,7 @@ end
     a = table([1],[2], names=[:x,:y])
     b = table([1],[3], names=[:a,:b])
     @test join(a, b, lkey=:x,rkey=:a) == table([1],[2],[3], names=[:x,:y,:b]) # issue JuliaDB.jl#105
+    @test join(a, b, lkey=Not(:y), rkey = Not(:b)) == join(a, b, lkey=:x,rkey=:a)
     @test join(l, r, how=:anti) == table([2, 2], [1, 2], [3, 4], names=Symbol[:a, :b, :c])
     l1 = table([1, 2, 2, 3], [1, 2, 3, 4], names=[:x, :y])
     r1 = table([2, 2, 3, 3], [5, 6, 7, 8], names=[:x, :z])
@@ -816,6 +819,7 @@ end
     @test groupreduce(+, t, :x, select=:z) == table([1, 2], [6, 15], names=Symbol[:x, :+])
     @test groupreduce(+, t, (:x, :y), select=:z) == table([1, 1, 2, 2], [1, 2, 1, 2], [3, 3, 11, 4], names=Symbol[:x, :y, :+])
     @test groupreduce((+, min, max), t, (:x, :y), select=:z) == table([1, 1, 2, 2], [1, 2, 1, 2], [3, 3, 11, 4], [1, 3, 5, 4], [2, 3, 6, 4], names=Symbol[:x, :y, :+, :min, :max])
+    @test groupreduce((+, min, max), t, All(:x, :y), select=:z) == groupreduce((+, min, max), t, (:x, :y), select=:z)
     @test groupreduce(@NT(zsum = (+), zmin = min, zmax = max), t, (:x, :y), select=:z) == table([1, 1, 2, 2], [1, 2, 1, 2], [3, 3, 11, 4], [1, 3, 5, 4], [2, 3, 6, 4], names=Symbol[:x, :y, :zsum, :zmin, :zmax])
     @test groupreduce(@NT(xsum = :z => +, negysum = (:y => -) => +), t, :x) == table([1, 2], [6, 15], [-4, -4], names=Symbol[:x, :xsum, :negysum])
     t = NDSparse([1, 1, 1, 1, 2, 2],
@@ -830,6 +834,7 @@ end
 
     a = table(x, pkey=[1,2], presorted=true)
     @test groupby(maximum, a, select=3) == table(Columns(a=[1, 1], b=[2, 3], maximum=[4, 5]))
+    @test groupby(identity, a, Keys()) == groupby(identity, a)
 
     @test groupby((maximum, minimum), a, select=3) ==
                 table(Columns(a=[1, 1], b=[2, 3],

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -444,6 +444,7 @@ end
     t = table([2, 1], [1, 3], [4, 5], names=[:x, :y, :z], pkey=(1, 2))
     @test reindex(t, (:y, :z)) == table([1, 3], [4, 5], [2, 1], names=Symbol[:y, :z, :x])
     @test reindex(t, Not(:x)) == reindex(t, (:y, :z))
+    @test reindex(t, Not(:x), r"x") == reindex(t, (:y, :z), (:x,))
     @test pkeynames(t) == (:x, :y)
     @test reindex(t, (:w => [4, 5], :z)) == table([4, 5], [5, 4], [1, 2], [3, 1], names=Symbol[:w, :z, :x, :y])
     @test pkeynames(t) == (:x, :y)


### PR DESCRIPTION
Call `lowerselection` wherever needed to allow use of  `SpecialSelector` in `by` and `select` everywhere.