### PR TITLE
flatten usability improvements

### DIFF
--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -164,9 +164,10 @@ function _flatten!(others, vecvec, out_others, out_vecvec)
 end
 
 """
-`flatten(t::Table, col)`
+`flatten(t::Table, col=length(columns(t)))`
 
 Flatten `col` column which may contain a vector of vectors while repeating the other fields.
+If column argument is not provided, default to last column.
 
 ## Examples:
 
@@ -201,8 +202,9 @@ x  a  b
 ```
 
 """
-function flatten(t::NextTable, col; pkey=nothing)
+function flatten(t::NextTable, col=length(columns(t)); pkey=nothing)
     vecvec = rows(t, col)
+    method_exists(start, (eltype(vecvec),)) || return t
     everythingbut = excludecols(t, col)
 
     order_others = Int[colindex(t, everythingbut)...]

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -1017,6 +1017,7 @@ end
 @testset "flatten" begin
     x = table([1,2], [[3,4], [5,6]], names=[:x, :y])
     @test flatten(x, 2) == table([1,1,2,2], [3,4,5,6], names=[:x,:y])
+    @test flatten(x, 2) == flatten(x)
 
     x = table([1,2], [table([3,4],[5,6], names=[:a,:b]), table([7,8], [9,10], names=[:a,:b])], names=[:x, :y]);
     @test flatten(x, :y) == table([1,1,2,2], [3,4,7,8], [5,6,9,10], names=[:x,:a, :b])
@@ -1027,6 +1028,8 @@ end
     t=table([1,1,1,2,2,2], [1,1,2,1,1,2], [1,2,3,4,5,6], names=[:x,:y,:z], pkey=[1,2]);
     @test groupby(identity, t, (:x, :y), select=:z, flatten = true) == renamecol(t, :z, :identity)
     @test groupby(identity, t, (:x, :y), select=:z, flatten = true).pkey == [1,2]
+    # If return type is non iterable, return the same as non flattened
+    @test groupby(i -> @NT(y = :y), t, :x, flatten=true) == groupby(i -> @NT(y = :y), t, :x, flatten=false)
 end
 
 @testset "ColDict" begin


### PR DESCRIPTION
A couple of usability improvements for `flatten`:

- Default to last column. It allows `groupby(identity, t, col) |> flatten`
- Do not error if eltype of column to flatten is non-iterable, but simply return the same table. This allow `groupby(f, t, col, flatten = true)` to work with greater generality.