### PR TITLE
indexing usability improvements

### DIFF
--- a/src/table.jl
+++ b/src/table.jl
@@ -306,7 +306,8 @@ Base.getindex(t::NextTable, i::Colon) = copy(t)
 Base.endof(t::NextTable) = length(t)
 
 function Base.view(t::NextTable, I)
-    issorted(I) || throw(ArgumentError("`view` called with unsorted index."))
+    t.pkey == Int64[] || eltype(I) == Bool || issorted(I) ||
+        throw(ArgumentError("`view` called with unsorted index."))
     table(
         view(t.columns, I),
         pkey = t.pkey,
@@ -319,7 +320,7 @@ Base.start(t::NextTable) = start(t.columns)
 Base.next(t::NextTable, i) = next(t.columns, i)
 Base.done(t::NextTable, i) = done(t.columns, i)
 function getindex(t::NextTable, idxs::AbstractVector{<:Integer})
-    if issorted(idxs)
+    if t.pkey == Int64[] || eltype(idxs) == Bool || issorted(idxs)
        #perms = map(t.perms) do p
        #    # TODO: make the ranks continuous
        #    Perm(p.columns, p.perm[idxs])

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -392,8 +392,12 @@ end
     t = table(cs, copy=false, pkey=:x)
 
     @test t[1] == @NT(x=1.2, y=3)
+    @test t[[true, false]] == t[[1]]
     @test t[[1,2]].columns == t.columns
     @test_throws ArgumentError t[[2,1]]
+
+    s = table(cs)
+    @test s[[2,1]] == table(rows(s)[[2,1]])
 end
 
 @testset "view & range" begin
@@ -403,6 +407,8 @@ end
     v = collect(1:10)
     t = view(table(v), 1:2)
     @test columns(t, 1) == view(v, 1:2)
+    @test view(table(1:2), [true, false]) == view(table(1:2), [1])
+    @test_throws ArgumentError view(table(1:2, pkey = 1), [2,1])
 end
 
 @testset "sortpermby" begin


### PR DESCRIPTION
This allows to call `getindex` and `view` with logical indexing (i.e. `t[[true, false]]`), whereas before it errored due to indexes being unsorted (which is incorrect, as this kind of indexing is always sorted).

I also allow unsorted indices if there are no primary keys. If there are primary keys, I can't quite decide whether we should remove those keys or error, I've left the error so far.