### PR TITLE
WIP: collect without inference

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -10,7 +10,7 @@ import Base:
     permutedims, reducedim, serialize, deserialize, sort, sort!
 
 export NDSparse, flush!, aggregate!, aggregate_vec, where, pairs, convertdim, columns, column, rows,
-    itable, update!, aggregate, reducedim_vec, dimlabels, collectcolumns
+    itable, update!, aggregate, reducedim_vec, dimlabels, collect_columns
 
 const Tup = Union{Tuple,NamedTuple}
 const DimName = Union{Int,Symbol}

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -10,7 +10,7 @@ import Base:
     permutedims, reducedim, serialize, deserialize, sort, sort!
 
 export NDSparse, flush!, aggregate!, aggregate_vec, where, pairs, convertdim, columns, column, rows,
-    itable, update!, aggregate, reducedim_vec, dimlabels
+    itable, update!, aggregate, reducedim_vec, dimlabels, collectcolumns
 
 const Tup = Union{Tuple,NamedTuple}
 const DimName = Union{Int,Symbol}
@@ -19,6 +19,7 @@ include("utils.jl")
 include("columns.jl")
 include("table.jl")
 include("ndsparse.jl")
+include("collect.jl")
 
 #=
 # Poor man's traits

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -4,7 +4,7 @@
 Collect an iterable as a `Columns` object if it iterates `Tuples` or `NamedTuples`, as a normal
 `Array` otherwise.
 
-## Example
+## Examples
 
 ```jldoctest collect
 julia> s = [(1,2), (3,4)];

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -14,11 +14,11 @@ function collect_to_columns!(dest::Columns{T, U}, itr, offs, st) where {T, U}
     i = offs
     while !done(itr, st)
         el, st = next(itr, st)
-        S = typeof(el)
-        if all((s <: t) for (s, t) in zip(S.parameters, T.parameters))
+        if fieldwise_isa(el, T)
             @inbounds dest[i] = el::T
             i += 1
         else
+            S = typeof(el)
             Rparams = map(typejoin, T.parameters, S.parameters)
             R = get_tuple_type_from_params(el, Rparams)
             new = similar(arrayof(R), length(itr))
@@ -32,3 +32,11 @@ end
 
 get_tuple_type_from_params(el::Tuple, params) = Tuple{params...}
 get_tuple_type_from_params(el::NamedTuple, params) = eval(:(NamedTuples.@NT($(keys(el)...)))){params...}
+
+@generated function fieldwise_isa(el::S, ::Type{T}) where {S, T}
+    if all((s <: t) for (s, t) in zip(S.parameters, T.parameters))
+        return :(true)
+    else
+        return :(false)
+    end
+end

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -1,0 +1,34 @@
+collectcolumns(itr) = collectcolumns(itr, Base.iteratorsize(itr))
+
+function collectcolumns(itr, ::Union{Base.HasShape, Base.HasLength})
+    st = start(itr)
+    el, st = next(itr, st)
+    dest = similar(arrayof(typeof(el)), length(itr))
+    dest[1] = el
+    collect_to_columns!(dest, itr, 2, st)
+end
+
+function collect_to_columns!(dest::Columns{T, U}, itr, offs, st) where {T, U}
+    # collect to dest array, checking the type of each result. if a result does not
+    # match, widen the result type and re-dispatch.
+    i = offs
+    while !done(itr, st)
+        el, st = next(itr, st)
+        S = typeof(el)
+        if all((s <: t) for (s, t) in zip(S.parameters, T.parameters))
+            @inbounds dest[i] = el::T
+            i += 1
+        else
+            Rparams = map(typejoin, T.parameters, S.parameters)
+            R = get_tuple_type_from_params(el, Rparams)
+            new = similar(arrayof(R), length(itr))
+            @inbounds for l in 1:i-1; new[l] = dest[l]; end
+            @inbounds new[i] = el
+            return collect_to_columns!(new, itr, i+1, st)
+        end
+    end
+    return dest
+end
+
+get_tuple_type_from_params(el::Tuple, params) = Tuple{params...}
+get_tuple_type_from_params(el::NamedTuple, params) = eval(:(NamedTuples.@NT($(keys(el)...)))){params...}

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -1,6 +1,6 @@
-collectcolumns(itr) = collectcolumns(itr, Base.iteratorsize(itr))
+collect_columns(itr) = collect_columns(itr, Base.iteratorsize(itr))
 
-function collectcolumns(itr, ::Union{Base.HasShape, Base.HasLength})
+function collect_columns(itr, ::Union{Base.HasShape, Base.HasLength})
     st = start(itr)
     el, st = next(itr, st)
     dest = similar(arrayof(typeof(el)), length(itr))
@@ -26,7 +26,7 @@ function collect_to_columns!(dest::AbstractArray{T}, itr, offs, st) where {T}
     return dest
 end
 
-function collectcolumns(itr, ::Base.SizeUnknown)
+function collect_columns(itr, ::Base.SizeUnknown)
     st = start(itr)
     el, st = next(itr, st)
     dest = similar(arrayof(typeof(el)), 1)

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -73,7 +73,7 @@ function widencolumns(dest, i, el::S, ::Type{T}) where{S <: Tup, T}
     idx = find(!(s <: t) for (s, t) in zip(sp, tp))
     new = dest
     for l in idx
-        newcol = Array{typejoin(sp[l], tp[l])}(length(dest))
+        newcol = Array{promote_type(sp[l], tp[l])}(length(dest))
         copy!(newcol, 1, column(dest, l), 1, i-1)
         new = setcol(new, l, newcol)
     end
@@ -81,7 +81,7 @@ function widencolumns(dest, i, el::S, ::Type{T}) where{S <: Tup, T}
 end
 
 function widencolumns(dest, i, el::S, ::Type{T}) where{S, T}
-    new = Array{typejoin(S, T)}(length(dest))
+    new = Array{promote_type(S, T)}(length(dest))
     copy!(new, 1, dest, 1, i-1)
     new
 end

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -1,3 +1,29 @@
+"""
+`collect_columns(itr)`
+
+Collect an iterable as a `Columns` object if it iterates `Tuples` or `NamedTuples`, as a normal
+`Array` otherwise.
+
+## Example
+
+```jldoctest collect
+julia> s = [(1,2), (3,4)];
+
+julia> collect_columns(s)
+2-element Columns{Tuple{Int64,Int64}}:
+ (1, 2)
+ (3, 4)
+
+ julia> s = Iterators.filter(isodd, 1:8);
+
+ julia> collect_columns(s)
+ 4-element Array{Int64,1}:
+  1
+  3
+  5
+  7
+```
+"""
 collect_columns(itr) = collect_columns(itr, Base.iteratorsize(itr))
 
 function collect_columns(itr, ::Union{Base.HasShape, Base.HasLength})

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -15,7 +15,7 @@ function collect_to_columns!(dest::Columns{T, U}, itr, offs, st) where {T, U}
     while !done(itr, st)
         el, st = next(itr, st)
         if fieldwise_isa(el, T)
-            @inbounds dest[i] = el::T
+            @inbounds dest[i] = el
             i += 1
         else
             S = typeof(el)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,5 +10,6 @@ using Base.Test
 include("test_core.jl")
 include("test_utils.jl")
 include("test_tabletraits.jl")
+include("test_collect.jl")
 
 end

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -11,13 +11,16 @@
     @inferred IndexedTables.collect_to_columns!(dest, itr, 2, st)
 
     v = [@NT(a = 1, b = 2), @NT(a = 1.2, b = 3)]
-    @test collect_columns(v) == Columns(@NT(a = Real[1, 1.2], b = Int[2, 3]))
+    @test collect_columns(v) == Columns(@NT(a = [1, 1.2], b = Int[2, 3]))
+    @test typeof(collect_columns(v)) == typeof(Columns(@NT(a = [1, 1.2], b = Int[2, 3])))
 
     v = [@NT(a = 1, b = 2), @NT(a = 1.2, b = "3")]
-    @test collect_columns(v) == Columns(@NT(a = Real[1, 1.2], b = Any[2, "3"]))
+    @test collect_columns(v) == Columns(@NT(a = [1, 1.2], b = Any[2, "3"]))
+    @test typeof(collect_columns(v)) == typeof(Columns(@NT(a = [1, 1.2], b = Any[2, "3"])))
 
     v = [@NT(a = 1, b = 2), @NT(a = 1.2, b = 2), @NT(a = 1, b = "3")]
-    @test collect_columns(v) == Columns(@NT(a = Real[1, 1.2, 1], b = Any[2, 2, "3"]))
+    @test collect_columns(v) == Columns(@NT(a = [1, 1.2, 1], b = Any[2, 2, "3"]))
+    @test typeof(collect_columns(v)) == typeof(Columns(@NT(a = [1, 1.2, 1], b = Any[2, 2, "3"])))
 
     # length unknown
     itr = Iterators.filter(isodd, 1:8)
@@ -33,19 +36,21 @@ end
     @inferred collect_columns(v)
 
     v = [(1, 2), (1.2, 3)]
-    @test collect_columns(v) == Columns((Real[1, 1.2], Int[2, 3]))
+    @test collect_columns(v) == Columns(([1, 1.2], Int[2, 3]))
 
     v = [(1, 2), (1.2, "3")]
-    @test collect_columns(v) == Columns((Real[1, 1.2], Any[2, "3"]))
+    @test collect_columns(v) == Columns(([1, 1.2], Any[2, "3"]))
+    @test typeof(collect_columns(v)) == typeof(Columns(([1, 1.2], Any[2, "3"])))
 
     v = [(1, 2), (1.2, 2), (1, "3")]
-    @test collect_columns(v) == Columns((Real[1, 1.2, 1], Any[2, 2, "3"]))
+    @test collect_columns(v) == Columns(([1, 1.2, 1], Any[2, 2, "3"]))
     # length unknown
     itr = Iterators.filter(isodd, 1:8)
     tuple_itr = ((i+1, i-1) for i in itr)
     @test collect_columns(tuple_itr) == Columns(([2, 4, 6, 8], [0, 2, 4, 6]))
     tuple_itr_real = (i == 1 ? (1.2, i-1) : (i+1, i-1) for i in itr)
-    @test collect_columns(tuple_itr_real) == Columns((Real[1.2, 4, 6, 8], [0, 2, 4, 6]))
+    @test collect_columns(tuple_itr_real) == Columns(([1.2, 4, 6, 8], [0, 2, 4, 6]))
+    @test typeof(collect_columns(tuple_itr_real)) == typeof(Columns(([1.2, 4, 6, 8], [0, 2, 4, 6])))
 end
 
 @testset "collectscalars" begin
@@ -60,4 +65,5 @@ end
     @test collect_columns(itr) == collect(itr)
     real_itr = (i == 1 ? 1.5 : i for i in itr)
     @test collect_columns(real_itr) == collect(real_itr)
+    @test eltype(collect_columns(real_itr)) == Float64
 end

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -1,6 +1,7 @@
 @testset "collectnamedtuples" begin
     v = [@NT(a = 1, b = 2), @NT(a = 1, b = 3)]
     @test collectcolumns(v) == Columns(@NT(a = Int[1, 1], b = Int[2, 3]))
+    #@inferred collectcolumns(v)
 
     v = [@NT(a = 1, b = 2), @NT(a = 1.2, b = 3)]
     @test collectcolumns(v) == Columns(@NT(a = Real[1, 1.2], b = Int[2, 3]))
@@ -15,6 +16,7 @@ end
 @testset "collecttuples" begin
     v = [(1, 2), (1, 3)]
     @test collectcolumns(v) == Columns((Int[1, 1], Int[2, 3]))
+    @inferred collectcolumns(v)
 
     v = [(1, 2), (1.2, 3)]
     @test collectcolumns(v) == Columns((Real[1, 1.2], Int[2, 3]))

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -1,6 +1,6 @@
 @testset "collectnamedtuples" begin
     v = [@NT(a = 1, b = 2), @NT(a = 1, b = 3)]
-    @test collectcolumns(v) == Columns(@NT(a = Int[1, 1], b = Int[2, 3]))
+    @test collect_columns(v) == Columns(@NT(a = Int[1, 1], b = Int[2, 3]))
 
     # test inferrability with constant eltype
     itr = [@NT(a = 1, b = 2), @NT(a = 1, b = 2), @NT(a = 1, b = 12)]
@@ -11,53 +11,53 @@
     @inferred IndexedTables.collect_to_columns!(dest, itr, 2, st)
 
     v = [@NT(a = 1, b = 2), @NT(a = 1.2, b = 3)]
-    @test collectcolumns(v) == Columns(@NT(a = Real[1, 1.2], b = Int[2, 3]))
+    @test collect_columns(v) == Columns(@NT(a = Real[1, 1.2], b = Int[2, 3]))
 
     v = [@NT(a = 1, b = 2), @NT(a = 1.2, b = "3")]
-    @test collectcolumns(v) == Columns(@NT(a = Real[1, 1.2], b = Any[2, "3"]))
+    @test collect_columns(v) == Columns(@NT(a = Real[1, 1.2], b = Any[2, "3"]))
 
     v = [@NT(a = 1, b = 2), @NT(a = 1.2, b = 2), @NT(a = 1, b = "3")]
-    @test collectcolumns(v) == Columns(@NT(a = Real[1, 1.2, 1], b = Any[2, 2, "3"]))
+    @test collect_columns(v) == Columns(@NT(a = Real[1, 1.2, 1], b = Any[2, 2, "3"]))
 
     # length unknown
     itr = Iterators.filter(isodd, 1:8)
     tuple_itr = (@NT(a = i+1, b = i-1) for i in itr)
-    @test collectcolumns(tuple_itr) == Columns(@NT(a = [2, 4, 6, 8], b = [0, 2, 4, 6]))
+    @test collect_columns(tuple_itr) == Columns(@NT(a = [2, 4, 6, 8], b = [0, 2, 4, 6]))
     tuple_itr_real = (i == 1 ? @NT(a = 1.2, b =i-1) : @NT(a = i+1, b = i-1) for i in itr)
-    @test collectcolumns(tuple_itr_real) == Columns(@NT(a = Real[1.2, 4, 6, 8], b = [0, 2, 4, 6]))
+    @test collect_columns(tuple_itr_real) == Columns(@NT(a = Real[1.2, 4, 6, 8], b = [0, 2, 4, 6]))
 end
 
 @testset "collecttuples" begin
     v = [(1, 2), (1, 3)]
-    @test collectcolumns(v) == Columns((Int[1, 1], Int[2, 3]))
-    @inferred collectcolumns(v)
+    @test collect_columns(v) == Columns((Int[1, 1], Int[2, 3]))
+    @inferred collect_columns(v)
 
     v = [(1, 2), (1.2, 3)]
-    @test collectcolumns(v) == Columns((Real[1, 1.2], Int[2, 3]))
+    @test collect_columns(v) == Columns((Real[1, 1.2], Int[2, 3]))
 
     v = [(1, 2), (1.2, "3")]
-    @test collectcolumns(v) == Columns((Real[1, 1.2], Any[2, "3"]))
+    @test collect_columns(v) == Columns((Real[1, 1.2], Any[2, "3"]))
 
     v = [(1, 2), (1.2, 2), (1, "3")]
-    @test collectcolumns(v) == Columns((Real[1, 1.2, 1], Any[2, 2, "3"]))
+    @test collect_columns(v) == Columns((Real[1, 1.2, 1], Any[2, 2, "3"]))
     # length unknown
     itr = Iterators.filter(isodd, 1:8)
     tuple_itr = ((i+1, i-1) for i in itr)
-    @test collectcolumns(tuple_itr) == Columns(([2, 4, 6, 8], [0, 2, 4, 6]))
+    @test collect_columns(tuple_itr) == Columns(([2, 4, 6, 8], [0, 2, 4, 6]))
     tuple_itr_real = (i == 1 ? (1.2, i-1) : (i+1, i-1) for i in itr)
-    @test collectcolumns(tuple_itr_real) == Columns((Real[1.2, 4, 6, 8], [0, 2, 4, 6]))
+    @test collect_columns(tuple_itr_real) == Columns((Real[1.2, 4, 6, 8], [0, 2, 4, 6]))
 end
 
 @testset "collectscalars" begin
     v = (i for i in 1:3)
-    @test collectcolumns(v) == [1,2,3]
-    @inferred collectcolumns(v)
+    @test collect_columns(v) == [1,2,3]
+    @inferred collect_columns(v)
 
     v = (i == 1 ? 1.2 : i for i in 1:3)
-    @test collectcolumns(v) == collect(v)
+    @test collect_columns(v) == collect(v)
 
     itr = Iterators.filter(isodd, 1:100)
-    @test collectcolumns(itr) == collect(itr)
+    @test collect_columns(itr) == collect(itr)
     real_itr = (i == 1 ? 1.5 : i for i in itr)
-    @test collectcolumns(real_itr) == collect(real_itr)
+    @test collect_columns(real_itr) == collect(real_itr)
 end

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -6,7 +6,7 @@
     itr = [@NT(a = 1, b = 2), @NT(a = 1, b = 2), @NT(a = 1, b = 12)]
     st = start(itr)
     el, st = next(itr, st)
-    dest = IndexedTables.arrayof(eltype(el), 3)
+    dest = similar(IndexedTables.arrayof(typeof(el)), 3)
     dest[1] = el
     @inferred IndexedTables.collect_to_columns!(dest, itr, 2, st)
 

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -1,0 +1,27 @@
+@testset "collectnamedtuples" begin
+    v = [@NT(a = 1, b = 2), @NT(a = 1, b = 3)]
+    @test collectcolumns(v) == Columns(@NT(a = Int[1, 1], b = Int[2, 3]))
+
+    v = [@NT(a = 1, b = 2), @NT(a = 1.2, b = 3)]
+    @test collectcolumns(v) == Columns(@NT(a = Real[1, 1.2], b = Int[2, 3]))
+
+    v = [@NT(a = 1, b = 2), @NT(a = 1.2, b = "3")]
+    @test collectcolumns(v) == Columns(@NT(a = Real[1, 1.2], b = Any[2, "3"]))
+
+    v = [@NT(a = 1, b = 2), @NT(a = 1.2, b = 2), @NT(a = 1, b = "3")]
+    @test collectcolumns(v) == Columns(@NT(a = Real[1, 1.2, 1], b = Any[2, 2, "3"]))
+end
+
+@testset "collecttuples" begin
+    v = [(1, 2), (1, 3)]
+    @test collectcolumns(v) == Columns((Int[1, 1], Int[2, 3]))
+
+    v = [(1, 2), (1.2, 3)]
+    @test collectcolumns(v) == Columns((Real[1, 1.2], Int[2, 3]))
+
+    v = [(1, 2), (1.2, "3")]
+    @test collectcolumns(v) == Columns((Real[1, 1.2], Any[2, "3"]))
+
+    v = [(1, 2), (1.2, 2), (1, "3")]
+    @test collectcolumns(v) == Columns((Real[1, 1.2, 1], Any[2, 2, "3"]))
+end

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -34,3 +34,12 @@ end
     v = [(1, 2), (1.2, 2), (1, "3")]
     @test collectcolumns(v) == Columns((Real[1, 1.2, 1], Any[2, 2, "3"]))
 end
+
+@testset "collectscalars" begin
+    v = (i for i in 1:3)
+    @test collectcolumns(v) == [1,2,3]
+    @inferred collectcolumns(v)
+
+    v = (i == 1 ? 1.2 : i for i in 1:3)
+    @test collectcolumns(v) == collect(v)
+end

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -18,6 +18,13 @@
 
     v = [@NT(a = 1, b = 2), @NT(a = 1.2, b = 2), @NT(a = 1, b = "3")]
     @test collectcolumns(v) == Columns(@NT(a = Real[1, 1.2, 1], b = Any[2, 2, "3"]))
+
+    # length unknown
+    itr = Iterators.filter(isodd, 1:8)
+    tuple_itr = (@NT(a = i+1, b = i-1) for i in itr)
+    @test collectcolumns(tuple_itr) == Columns(@NT(a = [2, 4, 6, 8], b = [0, 2, 4, 6]))
+    tuple_itr_real = (i == 1 ? @NT(a = 1.2, b =i-1) : @NT(a = i+1, b = i-1) for i in itr)
+    @test collectcolumns(tuple_itr_real) == Columns(@NT(a = Real[1.2, 4, 6, 8], b = [0, 2, 4, 6]))
 end
 
 @testset "collecttuples" begin
@@ -33,6 +40,12 @@ end
 
     v = [(1, 2), (1.2, 2), (1, "3")]
     @test collectcolumns(v) == Columns((Real[1, 1.2, 1], Any[2, 2, "3"]))
+    # length unknown
+    itr = Iterators.filter(isodd, 1:8)
+    tuple_itr = ((i+1, i-1) for i in itr)
+    @test collectcolumns(tuple_itr) == Columns(([2, 4, 6, 8], [0, 2, 4, 6]))
+    tuple_itr_real = (i == 1 ? (1.2, i-1) : (i+1, i-1) for i in itr)
+    @test collectcolumns(tuple_itr_real) == Columns((Real[1.2, 4, 6, 8], [0, 2, 4, 6]))
 end
 
 @testset "collectscalars" begin
@@ -42,4 +55,9 @@ end
 
     v = (i == 1 ? 1.2 : i for i in 1:3)
     @test collectcolumns(v) == collect(v)
+
+    itr = Iterators.filter(isodd, 1:100)
+    @test collectcolumns(itr) == collect(itr)
+    real_itr = (i == 1 ? 1.5 : i for i in itr)
+    @test collectcolumns(real_itr) == collect(real_itr)
 end

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -1,7 +1,14 @@
 @testset "collectnamedtuples" begin
     v = [@NT(a = 1, b = 2), @NT(a = 1, b = 3)]
     @test collectcolumns(v) == Columns(@NT(a = Int[1, 1], b = Int[2, 3]))
-    #@inferred collectcolumns(v)
+
+    # test inferrability with constant eltype
+    itr = [@NT(a = 1, b = 2), @NT(a = 1, b = 2), @NT(a = 1, b = 12)]
+    st = start(itr)
+    el, st = next(itr, st)
+    dest = IndexedTables.arrayof(eltype(el), 3)
+    dest[1] = el
+    @inferred IndexedTables.collect_to_columns!(dest, itr, 2, st)
 
     v = [@NT(a = 1, b = 2), @NT(a = 1.2, b = 3)]
     @test collectcolumns(v) == Columns(@NT(a = Real[1, 1.2], b = Int[2, 3]))


### PR DESCRIPTION
Collect an iterable of `Tuples` or `NamedTuples` to a `Columns` object, without using inference. The `Columns` object is initialized with the type of the first element and progressively widened, should this type change.
I assume that the iterator iterates `Tuples` (or `NamedTuples`) always of the same length and, in the `NamedTuples` case, always with the same fieldnames.

The condition to trigger widening is that at least one field of the iterate tuple is not a subtype of the `eltype` of the corresponding  column.

Widening happens element-wise, meaning I perform `typejoin` on a field by field basis.

To work with `missing` in the future `typejoin` is not the correct operation, as:

```julia
julia> typejoin(Missing, Int)
Any
```

but `Base.promote_typejoin` should be sufficient to fix this.

The overall strategy is more or less a copy-paste of Base Julia strategy to collect generators of unknown type.