### PR TITLE
map no longer relies on inference

### DIFF
--- a/src/collect.jl
+++ b/src/collect.jl
@@ -79,6 +79,7 @@ function grow_to_columns!(dest::AbstractArray{T}, itr, offs, st) where {T}
 end
 
 # extra methods if we have widened to Vector{Tuple} or Vector{NamedTuple}
+# better to not generate as this is the case where the user is sending heterogenoeus data
 fieldwise_isa(el::S, ::Type{Tuple}) where {S<:Tup} = S <: Tuple
 fieldwise_isa(el::S, ::Type{NamedTuple}) where {S<:Tup} = S <: NamedTuple
 

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -99,7 +99,11 @@ end
 end
 
 function widencolumns(dest, i, el::S, ::Type{T}) where{S <: Tup, T<:Tup}
-    if fieldnames(S) == fieldnames(T)
+    if fieldnames(S) != fieldnames(T) || S == Tuple || S == NamedTuple
+        R = (S <: Tuple) && (T <: Tuple) ? Tuple :  (S <: NamedTuple) && (T <: NamedTuple) ? NamedTuple : Any
+        new = Array{R}(length(dest))
+        copy!(new, 1, dest, 1, i-1)
+    else
         sp, tp = S.parameters, T.parameters
         idx = find(!(s <: t) for (s, t) in zip(sp, tp))
         new = dest
@@ -108,10 +112,6 @@ function widencolumns(dest, i, el::S, ::Type{T}) where{S <: Tup, T<:Tup}
             copy!(newcol, 1, column(dest, l), 1, i-1)
             new = setcol(new, l, newcol)
         end
-    else
-        R = (S <: Tuple) && (T <: Tuple) ? Tuple :  (S <: NamedTuple) && (T <: NamedTuple) ? NamedTuple : Any
-        new = Array{R}(length(dest))
-        copy!(new, 1, dest, 1, i-1)
     end
     new
 end

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -99,7 +99,7 @@ end
 end
 
 function widencolumns(dest, i, el::S, ::Type{T}) where{S <: Tup, T<:Tup}
-    if fieldnames(S) != fieldnames(T) || S == Tuple || S == NamedTuple
+    if fieldnames(S) != fieldnames(T) || T == Tuple || T == NamedTuple
         R = (S <: Tuple) && (T <: Tuple) ? Tuple :  (S <: NamedTuple) && (T <: NamedTuple) ? NamedTuple : Any
         new = Array{R}(length(dest))
         copy!(new, 1, dest, 1, i-1)

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -444,6 +444,9 @@ function map_rows(f, iters...)
     collect_columns(f(i...) for i in zip(iters...))
 end
 
+# 1-arg case
+map_rows(f, iter) = collect_columns(f(i) for i in iter)
+
 ## Special selectors to simplify column selector
 
 """

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -5,7 +5,7 @@ import Base:
     summary, resize!, vcat, serialize, deserialize, append!, copy!, view
 
 export Columns, colnames, ncols, ColDict, insertafter!, insertbefore!, @cols, setcol, pushcol, popcol, insertcol, insertcolafter, insertcolbefore, renamecol
-
+export map_rows
 export All, Not, Between, Keys
 
 """
@@ -417,6 +417,31 @@ end
         end
     end
     ex
+end
+
+# map
+
+"""
+`map_rows(f, c...)`
+
+Transform collection `c` by applying `f` to each element. For multiple collection arguments, apply `f`
+elementwise. Collect output as `Columns` if `f` returns
+`Tuples` or `NamedTuples` with constant fields, as `Array` otherwise.
+
+# Examples
+
+```jldoctest map_rows
+julia> map_rows(i -> @NT(exp = exp(i), log = log(i)), 1:5)
+5-element IndexedTables.Columns{NamedTuples._NT_exp_log{Float64,Float64},NamedTuples._NT_exp_log{Array{Float64,1},Array{Float64,1}}}:
+ (exp = 2.71828, log = 0.0)
+ (exp = 7.38906, log = 0.693147)
+ (exp = 20.0855, log = 1.09861)
+ (exp = 54.5982, log = 1.38629)
+ (exp = 148.413, log = 1.60944)
+```
+"""
+function map_rows(f, iters...)
+    collect_columns(f(i...) for i in zip(iters...))
 end
 
 ## Special selectors to simplify column selector

--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -426,10 +426,6 @@ convert(::Type{NDSparse}, ks, vs; kwargs...) = ndsparse(ks, vs; kwargs...)
 
 # map and convert
 
-function _map(f, xs)
-    collect_columns(f(i) for i in xs)
-end
-
 """
     map(f, x::NDSparse; select)
 
@@ -480,7 +476,7 @@ t    │
 ```
 """
 function map(f, x::NDSparse; select=x.data)
-    ndsparse(copy(x.index), _map(f, rows(x, select)),
+    ndsparse(copy(x.index), map_rows(f, rows(x, select)),
              presorted=true, copy=false)
 end
 

--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -427,14 +427,7 @@ convert(::Type{NDSparse}, ks, vs; kwargs...) = ndsparse(ks, vs; kwargs...)
 # map and convert
 
 function _map(f, xs)
-    T = _promote_op(f, eltype(xs))
-    if T<:Tup
-        out_T = arrayof(T)
-        out = similar(out_T, length(xs))
-        map!(f, out, xs)
-    else
-        map(f, xs)
-    end
+    collect_columns(f(i) for i in xs)
 end
 
 """

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -267,9 +267,7 @@ function map(f, t::Dataset; select=nothing)
         select = valuenames(t)
     end
 
-    fs, input, T = init_inputs(f, rows(t, select), mapped_type, false)
-    x = similar(arrayof(T), length(t))
-    map!(a->_apply(fs, a), x, input)
+    x = _map(f, rows(t, select))
     isa(x, Columns) ? table(x) : x
 end
 

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -267,7 +267,7 @@ function map(f, t::Dataset; select=nothing)
         select = valuenames(t)
     end
 
-    x = _map(f, rows(t, select))
+    x = map_rows(f, rows(t, select))
     isa(x, Columns) ? table(x) : x
 end
 

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -12,6 +12,7 @@ let c = Columns([1,1,1,2,2], [1,2,4,3,5]),
     @test map(+,NDSparse(c,ones(5)),NDSparse(d,ones(5))).index == Columns([1,2],[1,5])
     @test length(map(+,NDSparse(e,ones(3)),NDSparse(f,ones(3)))) == 1
     @test eltype(c) == Tuple{Int,Int}
+    @test map_rows(i -> @NT(exp = exp(i), log = log(i)), 1:5) == Columns(@NT(exp = exp.(1:5), log = log.(1:5)))
 end
 
 srand(123)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -572,7 +572,7 @@ end
 
     t3 = map(x->ntuple(identity, x.x), t)
     @test isa(t3.data, Vector)
-    @test eltype(t3.data) <: Tuple{Vararg{Int}}
+    @test eltype(t3.data) == Tuple
 
     y = [1, 1//2, "x"]
     function f(x)
@@ -581,6 +581,10 @@ end
     t4 = map(f, t)
     @test isa(t4.data, Columns)
     @test eltype(t4.data) <: Tuple{Int, Any}
+
+    t5 = table([1,2], ["a", "b"], names = [:x, :y])
+    s = [:x, :y]
+    @test map(i -> Tuple(getfield(i, j) for j in s), t5) == table([1,2], ["a", "b"])
 end
 
 @testset "join" begin

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -13,6 +13,7 @@ let c = Columns([1,1,1,2,2], [1,2,4,3,5]),
     @test length(map(+,NDSparse(e,ones(3)),NDSparse(f,ones(3)))) == 1
     @test eltype(c) == Tuple{Int,Int}
     @test map_rows(i -> @NT(exp = exp(i), log = log(i)), 1:5) == Columns(@NT(exp = exp.(1:5), log = log.(1:5)))
+    @test map_rows(tuple, 1:3, ["a","b","c"]) == Columns([1,2,3], ["a","b","c"])
 end
 
 srand(123)


### PR DESCRIPTION
I've addressed the last issues from #135 (allowing the user to give a mix of `NamedTuples` with different fields that gets stored as `Vector{NamedTuples}`) and update `map` to use the new `collect_columns`.