### PR TITLE
Define and collect Columns{Pair}

### DIFF
--- a/src/collect.jl
+++ b/src/collect.jl
@@ -99,6 +99,9 @@ end
     end
 end
 
+fieldwise_isa(el::Pair{<:Tup, <:Any}, ::Type{Pair{T1, T2}}) where {T1, T2}  =
+    fieldwise_isa(el.first, T1) && fieldwise_isa(el.second, T2)
+
 function widencolumns(dest, i, el::S, ::Type{T}) where{S <: Tup, T<:Tup}
     if fieldnames(S) != fieldnames(T) || T == Tuple || T == NamedTuple
         R = (S <: Tuple) && (T <: Tuple) ? Tuple :  (S <: NamedTuple) && (T <: NamedTuple) ? NamedTuple : Any
@@ -121,4 +124,10 @@ function widencolumns(dest, i, el::S, ::Type{T}) where{S, T}
     new = Array{promote_type(S, T)}(length(dest))
     copy!(new, 1, dest, 1, i-1)
     new
+end
+
+function widencolumns(dest::Columns{<:Pair}, i, el::Pair, ::Type{Columns{Pair{T1, T2}}}) where{T1, T2}
+    dest1 = fieldwise_isa(el.first, T1) ? dest.columns.first : widencolumns(dest.columns.first, i, el.first, T1)
+    dest2 = fieldwise_isa(el.second, T2) ? dest.columns.second : widencolumns(dest.columns.second, i, el.second, T1)
+    Columns(dest1 => dest2)
 end

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -99,7 +99,7 @@ end
     end
 end
 
-fieldwise_isa(el::Pair{<:Tup, <:Any}, ::Type{Pair{T1, T2}}) where {T1, T2}  =
+fieldwise_isa(el::Pair, ::Type{Pair{T1, T2}}) where {T1, T2}  =
     fieldwise_isa(el.first, T1) && fieldwise_isa(el.second, T2)
 
 function widencolumns(dest, i, el::S, ::Type{T}) where{S <: Tup, T<:Tup}
@@ -126,7 +126,7 @@ function widencolumns(dest, i, el::S, ::Type{T}) where{S, T}
     new
 end
 
-function widencolumns(dest::Columns{<:Pair}, i, el::Pair, ::Type{Columns{Pair{T1, T2}}}) where{T1, T2}
+function widencolumns(dest::Columns{<:Pair}, i, el::Pair, ::Type{Pair{T1, T2}}) where{T1, T2}
     dest1 = fieldwise_isa(el.first, T1) ? dest.columns.first : widencolumns(dest.columns.first, i, el.first, T1)
     dest2 = fieldwise_isa(el.second, T2) ? dest.columns.second : widencolumns(dest.columns.second, i, el.second, T1)
     Columns(dest1 => dest2)

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -325,6 +325,12 @@ function Base.vcat(c::Columns, cs::Columns...)
     Columns(map(vcat, map(x->x.columns, (c,cs...))...))
 end
 
+function Base.vcat(c::Columns{<:Pair}, cs::Columns{<:Pair}...)
+    Columns(vcat(c.columns.first, (x.columns.first for x in cs)...) =>
+            vcat(c.columns.second, (x.columns.second for x in cs)...))
+end
+
+
 abstract type SerializedColumns end
 
 function serialize(s::AbstractSerializer, c::Columns)

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -188,7 +188,7 @@ julia> ncols(ndsparse(d, [7,8,9]))
 """
 function ncols end
 ncols(c::Columns) = nfields(typeof(c.columns))
-ncols(c::Columns{<:Pair, <:Pair}) = ncols(c.columns.first) + ncols(c.columns.second)
+ncols(c::Columns{<:Pair, <:Pair}) = ncols(c.columns.first) => ncols(c.columns.second)
 ncols(c::AbstractArray) = 1
 
 size(c::Columns) = (length(c),)
@@ -196,7 +196,7 @@ Base.IndexStyle(::Type{<:Columns}) = IndexLinear()
 summary(c::Columns{D}) where {D<:Tuple} = "$(length(c))-element Columns{$D}"
 
 empty!(c::Columns) = (foreach(empty!, c.columns); c)
-empty!(c::Columns{<:Pair, <:Pair}) = (foreach(empty!, c.columns.first); foreach(empty!, c.columns.second); c)
+empty!(c::Columns{<:Pair, <:Pair}) = (foreach(empty!, c.columns.first.columns); foreach(empty!, c.columns.second.columns); c)
 
 function similar(c::Columns{D,C}) where {D,C}
     cols = map_pair(similar, c.columns)
@@ -309,7 +309,7 @@ function permute!(c::Columns, p::AbstractVector)
     end
     return c
 end
-permute!(c::Columns{<:Pair}, p) = (permute!(c.columns.first, p); permute!(c.columns.second, p); c)
+permute!(c::Columns{<:Pair}, p::AbstractVector) = (permute!(c.columns.first, p); permute!(c.columns.second, p); c)
 sort!(c::Columns) = permute!(c, sortperm(c))
 sort(c::Columns) = c[sortperm(c)]
 

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -15,7 +15,7 @@ A type that stores an array of tuples as a tuple of arrays.
 
 - `columns`: a tuple or named tuples of arrays. Also `columns(x)`
 """
-struct Columns{D<:Tup, C<:Tup} <: AbstractVector{D}
+struct Columns{D<:Union{Tup, Pair}, C<:Union{Tup, Pair}} <: AbstractVector{D}
     columns::C
 
     function Columns{D,C}(c) where {D<:Tup,C<:Tup}
@@ -24,6 +24,11 @@ struct Columns{D<:Tup, C<:Tup} <: AbstractVector{D}
         for i = 2:length(c)
             length(c[i]) == n || error("all columns must have same length")
         end
+        new{D,C}(c)
+    end
+
+    function Columns{D,C}(c::Pair) where {D<:Pair,C<:Pair{<:AbstractVector, <:AbstractVector}}
+        length(c.first) == length(c.second) || error("all columns must have same length")
         new{D,C}(c)
     end
 end
@@ -40,7 +45,7 @@ end
 
 Columns(; pairs...) = Columns(map(x->x[2],pairs)..., names=Symbol[x[1] for x in pairs])
 
-Columns(c::Tup) = Columns{eltypes(typeof(c)),typeof(c)}(c)
+Columns(c::Union{Tup, Pair}) = Columns{eltypes(typeof(c)),typeof(c)}(c)
 
 # IndexedTable-like API
 
@@ -111,6 +116,7 @@ Base.@pure colnames(t::AbstractVector) = [1]
 columns(v::AbstractVector) = v
 
 Base.@pure colnames(t::Columns) = fieldnames(eltype(t))
+Base.@pure colnames(t::Columns{<:Pair, <:Pair}) = colnames(t.columns.first) => colnames(t.columns.second)
 
 """
 `columns(itr[, select::Selection])`
@@ -155,6 +161,7 @@ columns(c::Columns) = c.columns
 
 eltype{D,C}(::Type{Columns{D,C}}) = D
 length(c::Columns) = length(c.columns[1])
+length(c::Columns{<:Pair, <:Pair}) = length(c.columns.first)
 ndims(c::Columns) = 1
 
 """
@@ -181,6 +188,7 @@ julia> ncols(ndsparse(d, [7,8,9]))
 """
 function ncols end
 ncols(c::Columns) = nfields(typeof(c.columns))
+ncols(c::Columns{<:Pair, <:Pair}) = ncols(c.columns.first) + ncols(c.columns.second)
 ncols(c::AbstractArray) = 1
 
 size(c::Columns) = (length(c),)
@@ -188,14 +196,15 @@ Base.IndexStyle(::Type{<:Columns}) = IndexLinear()
 summary(c::Columns{D}) where {D<:Tuple} = "$(length(c))-element Columns{$D}"
 
 empty!(c::Columns) = (foreach(empty!, c.columns); c)
+empty!(c::Columns{<:Pair, <:Pair}) = (foreach(empty!, c.columns.first); foreach(empty!, c.columns.second); c)
 
 function similar(c::Columns{D,C}) where {D,C}
-    cols = map(similar, c.columns)
+    cols = map_pair(similar, c.columns)
     Columns{D,typeof(cols)}(cols)
 end
 
 function similar(c::Columns{D,C}, n::Integer) where {D,C}
-    cols = map(a->similar(a,n), c.columns)
+    cols = map_pair(a->similar(a,n), c.columns)
     Columns{D,typeof(cols)}(cols)
 end
 
@@ -218,14 +227,15 @@ end
 
 getindex(c::Columns{D}, i::Integer) where {D<:Tuple} = ith_all(i, c.columns)
 getindex(c::Columns{D}, i::Integer) where {D<:NamedTuple} = D(ith_all(i, c.columns)...)
+getindex(c::Columns{D}, i::Integer) where {D<:Pair} = getindex(c.columns.first, i) => getindex(c.columns.second, i)
 
-getindex(c::Columns, p::AbstractVector) = Columns(map(c->c[p], c.columns))
+getindex(c::Columns, p::AbstractVector) = Columns(map_pair(c->c[p], c.columns))
 
-view(c::Columns, I) = Columns(map(a->view(a, I), c.columns))
+view(c::Columns, I) = Columns(map_pair(a->view(a, I), c.columns))
 
-@inline setindex!(I::Columns, r::Tup, i::Integer) = (foreach((c,v)->(c[i]=v), I.columns, r); I)
+@inline setindex!(I::Columns, r::Union{Tup, Pair}, i::Integer) = (foreach((c,v)->(c[i]=v), I.columns, r); I)
 
-@inline push!(I::Columns, r::Tup) = (foreach(push!, I.columns, r); I)
+@inline push!(I::Columns, r::Union{Tup, Pair}) = (foreach(push!, I.columns, r); I)
 
 append!(I::Columns, J::Columns) = (foreach(append!, I.columns, J.columns); I)
 
@@ -247,6 +257,10 @@ function ==(x::Columns, y::Columns)
     return true
 end
 
+==(x::Columns{<:Pair}, y::Columns) = false
+==(x::Columns, y::Columns{<:Pair}) = false
+==(x::Columns{<:Pair}, y::Columns{<:Pair}) = (x.columns.first == y.columns.first) && (x.columns.second == y.columns.second)
+
 sortproxy(x::PooledArray) = x.refs
 sortproxy(x::AbstractArray) = x
 
@@ -261,7 +275,10 @@ function sortperm(c::Columns)
     return p
 end
 
+sortperm(c::Columns{<:Pair}) = sortperm(c.columns.first)
+
 issorted(c::Columns) = issorted(1:length(c), lt=(x,y)->rowless(c, x, y))
+issorted(c::Columns{<:Pair}) = issorted(c.columns.first)
 
 # assuming x[p] is sorted, sort by remaining columns where x[p] is constant
 function refine_perm!(p, cols, c, x, y, lo, hi)
@@ -292,6 +309,7 @@ function permute!(c::Columns, p::AbstractVector)
     end
     return c
 end
+permute!(c::Columns{<:Pair}, p) = (permute!(c.columns.first, p); permute!(c.columns.second, p); c)
 sort!(c::Columns) = permute!(c, sortperm(c))
 sort(c::Columns) = c[sortperm(c)]
 

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -261,6 +261,13 @@ end
 ==(x::Columns, y::Columns{<:Pair}) = false
 ==(x::Columns{<:Pair}, y::Columns{<:Pair}) = (x.columns.first == y.columns.first) && (x.columns.second == y.columns.second)
 
+function _strip_pair(c::Columns{<:Pair})
+    f, s = map(columns, c.columns)
+    (f isa AbstractVector) && (f = (f,))
+    (s isa AbstractVector) && (s = (s,))
+    Columns(f..., s...)
+end
+
 sortproxy(x::PooledArray) = x.refs
 sortproxy(x::AbstractArray) = x
 
@@ -275,10 +282,10 @@ function sortperm(c::Columns)
     return p
 end
 
-sortperm(c::Columns{<:Pair}) = sortperm(c.columns.first)
+sortperm(c::Columns{<:Pair}) = sortperm(_strip_pair(c))
 
 issorted(c::Columns) = issorted(1:length(c), lt=(x,y)->rowless(c, x, y))
-issorted(c::Columns{<:Pair}) = issorted(c.columns.first)
+issorted(c::Columns{<:Pair}) = issorted(_strip_pair(c))
 
 # assuming x[p] is sorted, sort by remaining columns where x[p] is constant
 function refine_perm!(p, cols, c, x, y, lo, hi)

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -199,12 +199,12 @@ empty!(c::Columns) = (foreach(empty!, c.columns); c)
 empty!(c::Columns{<:Pair, <:Pair}) = (foreach(empty!, c.columns.first.columns); foreach(empty!, c.columns.second.columns); c)
 
 function similar(c::Columns{D,C}) where {D,C}
-    cols = map_pair(similar, c.columns)
+    cols = _map(similar, c.columns)
     Columns{D,typeof(cols)}(cols)
 end
 
 function similar(c::Columns{D,C}, n::Integer) where {D,C}
-    cols = map_pair(a->similar(a,n), c.columns)
+    cols = _map(a->similar(a,n), c.columns)
     Columns{D,typeof(cols)}(cols)
 end
 
@@ -229,9 +229,9 @@ getindex(c::Columns{D}, i::Integer) where {D<:Tuple} = ith_all(i, c.columns)
 getindex(c::Columns{D}, i::Integer) where {D<:NamedTuple} = D(ith_all(i, c.columns)...)
 getindex(c::Columns{D}, i::Integer) where {D<:Pair} = getindex(c.columns.first, i) => getindex(c.columns.second, i)
 
-getindex(c::Columns, p::AbstractVector) = Columns(map_pair(c->c[p], c.columns))
+getindex(c::Columns, p::AbstractVector) = Columns(_map(c->c[p], c.columns))
 
-view(c::Columns, I) = Columns(map_pair(a->view(a, I), c.columns))
+view(c::Columns, I) = Columns(_map(a->view(a, I), c.columns))
 
 @inline setindex!(I::Columns, r::Union{Tup, Pair}, i::Integer) = (foreach((c,v)->(c[i]=v), I.columns, r); I)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -307,8 +307,8 @@ Base.@pure function _promote_op{S,T}(f, ::Type{S}, ::Type{T})
     strip_unionall(t)
 end
 
-map_pair(f, p::Pair) = f(p.first) => f(p.second)
-map_pair(f, arg) = map(f, arg)
+_map(f, p::Pair) = f(p.first) => f(p.second)
+_map(f, args...) = map(f, args...)
 
 # The following is not inferable, this is OK because the only place we use
 # this doesn't need it.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,6 +8,8 @@ eltypes(::Type{Tuple{}}) = Tuple{}
 eltypes{T<:Tuple}(::Type{T}) =
     tuple_type_cons(eltype(tuple_type_head(T)), eltypes(tuple_type_tail(T)))
 eltypes{T<:NamedTuple}(::Type{T}) = map_params(eltype, T)
+eltypes(::Type{T}) where T <: Pair = map_params(eltypes, T)
+eltypes(::Type{T}) where T<:AbstractArray{S, N} where {S, N} = S
 Base.@pure astuple{T<:NamedTuple}(::Type{T}) = Tuple{T.parameters...}
 astuple{T<:Tuple}(::Type{T}) = T
 
@@ -37,6 +39,9 @@ end
 @generated function foreach(f, n::NamedTuple)
     Expr(:block, [ Expr(:call, :f, Expr(:., :n, Expr(:quote, fieldname(n,f)))) for f = 1:nfields(n) ]...)
 end
+
+@inline foreach(f, a::Pair) = (f(a.first); f(a.second))
+@inline foreach(f, a::Pair, b::Pair) = (f(a.first, b.first); f(a.second, b.second))
 
 @inline foreach(f, a::Tuple, b::Tuple) = _foreach(f, a[1], b[1], tail(a), tail(b))
 @inline _foreach(f, x, y, ra, rb) = (f(x, y); _foreach(f, ra[1], rb[1], tail(ra), tail(rb)))
@@ -240,6 +245,8 @@ Base.@pure function arrayof(S)
         Columns{T,namedtuple(fieldnames(T)...){map(arrayof, T.parameters)...}}
     elseif T<:DataValue
         DataValueArray{T.parameters[1],1}
+    elseif T<:Pair
+        Columns{T, Pair{map(arrayof, T.parameters)...}}
     else
         Vector{T}
     end
@@ -300,6 +307,9 @@ Base.@pure function _promote_op{S,T}(f, ::Type{S}, ::Type{T})
     strip_unionall(t)
 end
 
+map_pair(f, p::Pair) = f(p.first) => f(p.second)
+map_pair(f, arg) = map(f, arg)
+
 # The following is not inferable, this is OK because the only place we use
 # this doesn't need it.
 
@@ -311,6 +321,7 @@ _map_params(f, T::Type{Tuple{}},S::Type{Tuple{}}) = ()
 
 map_params(f, ::Type{T}, ::Type{S}) where {T,S} = f(T,S)
 map_params(f, ::Type{T}) where {T} = map_params((x,y)->f(x), T, T)
+map_params(f, ::Type{T}) where T <: Pair{S1, S2} where {S1, S2} = Pair{f(S1), f(S2)}
 @inline _tuple_type_head{T<:Tuple}(::Type{T}) = Base.tuple_type_head(T)
 @inline _tuple_type_tail{T<:Tuple}(::Type{T}) = Base.tuple_type_tail(T)
 

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -67,3 +67,21 @@ end
     @test collect_columns(real_itr) == collect(real_itr)
     @test eltype(collect_columns(real_itr)) == Float64
 end
+
+@testset "collectpairs" begin
+    v = (i=>i+1 for i in 1:3)
+    @test collect_columns(v) == Columns([1,2,3]=>[2,3,4])
+    @test eltype(collect_columns(v)) == Pair{Int, Int}
+
+    v = (i == 1 ? (1.2 => i+1) : (i => i+1) for i in 1:3)
+    @test collect_columns(v) == Columns([1.2,2,3]=>[2,3,4])
+    @test eltype(collect_columns(v)) == Pair{Float64, Int}
+
+    v = (@NT(a=i) => @NT(b="a$i") for i in 1:3)
+    @test collect_columns(v) == Columns(Columns(@NT(a = [1,2,3]))=>Columns(@NT(b = ["a1","a2","a3"])))
+    @test eltype(collect_columns(v)) == Pair{NamedTuples._NT_a{Int64}, NamedTuples._NT_b{String}}
+
+    v = (i == 1 ? @NT(a="1") => @NT(b="a$i") : @NT(a=i) => @NT(b="a$i") for i in 1:3)
+    @test collect_columns(v) == Columns(Columns(@NT(a = ["1",2,3]))=>Columns(@NT(b = ["a1","a2","a3"])))
+    @test eltype(collect_columns(v)) == Pair{NamedTuples._NT_a{Any}, NamedTuples._NT_b{String}}
+end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -16,6 +16,36 @@ let c = Columns([1,1,1,2,2], [1,2,4,3,5]),
     @test map_rows(tuple, 1:3, ["a","b","c"]) == Columns([1,2,3], ["a","b","c"])
 end
 
+let c = Columns(Columns(@NT(a=[1,2,3])) => Columns(@NT(b=["a","b","c"])))
+    @test c.columns.first == Columns(@NT(a=[1,2,3]))
+    @test c.columns.second == Columns(@NT(b=["a","b","c"]))
+    @test colnames(c) == ([:a] => [:b])
+    @test length(c) == 3
+    @test ncols(c) == (1 => 1)
+    @test eltype(c) == typeof(@NT(a=1)=>@NT(b="a"))
+    @test c[1] == (@NT(a=1) => @NT(b="a"))
+    @test c[1:2] ==  Columns(Columns(@NT(a=[1,2])) => Columns(@NT(b=["a","b"])))
+    @test view(c, 1:2) == Columns(Columns(@NT(a=view([1,2,3],1:2)))=>Columns(@NT(b=view(["a","b","c"],1:2))))
+    d = deepcopy(c)
+    d[1] = @NT(a=2) => @NT(b="aa")
+    @test d[1] == (@NT(a=2) => @NT(b="aa"))
+    d = deepcopy(c)
+    push!(d, @NT(a=4) => @NT(b="d"))
+    @test d == Columns(Columns(@NT(a=[1,2,3,4])) => Columns(@NT(b=["a","b","c","d"])))
+    append!(d, d)
+    @test d == Columns(Columns(@NT(a=[1,2,3,4,1,2,3,4])) => Columns(@NT(b=["a","b","c","d","a","b","c","d"])))
+    empty!(d)
+    @test d == c[Int64[]]
+    @test c != Columns(@NT(a=[1,2,3], b=["a","b","c"]))
+    @test IndexedTables.arrayof(eltype(c)) == typeof(c)
+    @test typeof(similar(c, 10)) == typeof(similar(typeof(c), 10)) == typeof(c)
+    @test length(similar(c, 10)) == 10
+    @test issorted(c)
+    @test sortperm(c) == [1,2,3]
+    permute!(c, [2,3, 1])
+    @test c == Columns(Columns(@NT(a=[2,3,1])) => Columns(@NT(b=["b","c","a"])))
+end
+
 srand(123)
 A = NDSparse(rand(1:3,10), rand('A':'F',10), map(UInt8,rand(1:3,10)), collect(1:10), randn(10))
 B = NDSparse(map(UInt8,rand(1:3,10)), rand('A':'F',10), rand(1:3,10), randn(10))

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -32,8 +32,10 @@ let c = Columns(Columns(@NT(a=[1,2,3])) => Columns(@NT(b=["a","b","c"])))
     d = deepcopy(c)
     push!(d, @NT(a=4) => @NT(b="d"))
     @test d == Columns(Columns(@NT(a=[1,2,3,4])) => Columns(@NT(b=["a","b","c","d"])))
+    e = vcat(d, d)
     append!(d, d)
     @test d == Columns(Columns(@NT(a=[1,2,3,4,1,2,3,4])) => Columns(@NT(b=["a","b","c","d","a","b","c","d"])))
+    @test d == e
     empty!(d)
     @test d == c[Int64[]]
     @test c != Columns(@NT(a=[1,2,3], b=["a","b","c"]))

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -46,6 +46,11 @@ let c = Columns(Columns(@NT(a=[1,2,3])) => Columns(@NT(b=["a","b","c"])))
     @test sortperm(c) == [1,2,3]
     permute!(c, [2,3, 1])
     @test c == Columns(Columns(@NT(a=[2,3,1])) => Columns(@NT(b=["b","c","a"])))
+    f = Columns(Columns([1, 1, 2, 2]) => ["b", "a", "c", "d"])
+    @test IndexedTables._strip_pair(f) == Columns([1, 1, 2, 2], ["b", "a", "c", "d"])
+    @test sortperm(f) == [2, 1, 3, 4]
+    @test sort(f) == Columns(Columns([1, 1, 2, 2]) => ["a", "b", "c", "d"])
+    @test !issorted(f)
 end
 
 srand(123)


### PR DESCRIPTION
Implementation of the proposal in #139. I would mainly use `Columns{Pair}` as an internal object without documenting it/recommending it to the user as  I have not yet implemented all the methods for `Columns` on `Columns{Pair}` (though most should be there already) and some I'm not sure whether it makes sense to implement at all. OTOH the most relevant methods are there and are enough for the `collect_columns` implementation to work for column pairs.