### PR TITLE
Avoid a too narrow value type in Dics in the table constructors in tabletraits.jl

### DIFF
--- a/src/tabletraits.jl
+++ b/src/tabletraits.jl
@@ -59,8 +59,8 @@ end
 
 function table(rows::AbstractArray{T}; kwargs...) where {T<:NamedTuple}
     source_data, source_names = TableTraitsUtils.create_columns_from_iterabletable(rows, array_factory=_array_factory)
-    
-    kwargs_dict = Dict(i[1]=>i[2] for i in kwargs)   
+
+    kwargs_dict = Dict{Symbol,Any}(i[1]=>i[2] for i in kwargs)
     kwargs_dict[:copy] = false
 
     return table(source_data..., names=source_names; kwargs_dict...)
@@ -70,7 +70,7 @@ function table(iter; kwargs...)
     if isiterabletable(iter)
         source_data, source_names = TableTraitsUtils.create_columns_from_iterabletable(iter, array_factory=_array_factory)
 
-        kwargs_dict = Dict(i[1]=>i[2] for i in kwargs)   
+        kwargs_dict = Dict{Symbol,Any}(i[1]=>i[2] for i in kwargs)
         kwargs_dict[:copy] = false
 
         return table(source_data..., names=source_names; kwargs_dict...)

--- a/test/test_tabletraits.jl
+++ b/test/test_tabletraits.jl
@@ -59,4 +59,14 @@ it4 = table(as_set, copy=true)
 @test contains(==, as_set, it4[2])
 @test contains(==, as_set, it4[3])
 
+@testset "avoid too narrow dict value type" begin
+    # The array constructor
+    @test table([@NT(col1 = "A")], pkey = [1]) ==
+            table(["A"], names = [:col1], pkey = [1])
+
+    # The iterator constructor
+    @test table(Iterators.repeated(@NT(col1 = "A"), 2), pkey = [1]) ==
+            table(["A", "A"], names = [:col1], pkey = [1])
+end
+
 end


### PR DESCRIPTION
I guess this happens all the time.