### PR TITLE
fix collect_columns for empty iterator 

### DIFF
--- a/src/collect.jl
+++ b/src/collect.jl
@@ -26,8 +26,14 @@ julia> collect_columns(s)
 """
 collect_columns(itr) = collect_columns(itr, Base.iteratorsize(itr))
 
+function collect_empty_columns(itr::T) where {T}
+    S = Core.Inference.return_type(first, Tuple{T})
+    similar(arrayof(S), 0)
+end
+
 function collect_columns(itr, ::Union{Base.HasShape, Base.HasLength})
     st = start(itr)
+    done(itr, st) && return collect_empty_columns(itr)
     el, st = next(itr, st)
     dest = similar(arrayof(typeof(el)), length(itr))
     dest[1] = el
@@ -54,6 +60,7 @@ end
 
 function collect_columns(itr, ::Base.SizeUnknown)
     st = start(itr)
+    done(itr, st) && return collect_empty_columns(itr)
     el, st = next(itr, st)
     dest = similar(arrayof(typeof(el)), 1)
     dest[1] = el

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -28,6 +28,15 @@
     @test collect_columns(tuple_itr) == Columns(@NT(a = [2, 4, 6, 8], b = [0, 2, 4, 6]))
     tuple_itr_real = (i == 1 ? @NT(a = 1.2, b =i-1) : @NT(a = i+1, b = i-1) for i in itr)
     @test collect_columns(tuple_itr_real) == Columns(@NT(a = Real[1.2, 4, 6, 8], b = [0, 2, 4, 6]))
+
+    # empty
+    itr = Iterators.filter(t -> t > 10, 1:8)
+    tuple_itr = (@NT(a = i+1, b = i-1) for i in itr)
+    @test collect_columns(tuple_itr) == Columns(@NT(a = Int[], b = Int[]))
+
+    itr = (i for i in 0:-1)
+    tuple_itr = (@NT(a = i+1, b = i-1) for i in itr)
+    @test collect_columns(tuple_itr) == Columns(@NT(a = Int[], b = Int[]))
 end
 
 @testset "collecttuples" begin
@@ -51,6 +60,15 @@ end
     tuple_itr_real = (i == 1 ? (1.2, i-1) : (i+1, i-1) for i in itr)
     @test collect_columns(tuple_itr_real) == Columns(([1.2, 4, 6, 8], [0, 2, 4, 6]))
     @test typeof(collect_columns(tuple_itr_real)) == typeof(Columns(([1.2, 4, 6, 8], [0, 2, 4, 6])))
+
+    # empty
+    itr = Iterators.filter(t -> t > 10, 1:8)
+    tuple_itr = ((i+1, i-1) for i in itr)
+    @test collect_columns(tuple_itr) == Columns(Int[], Int[])
+
+    itr = (i for i in 0:-1)
+    tuple_itr = ((i+1, i-1) for i in itr)
+    @test collect_columns(tuple_itr) == Columns(Int[], Int[])
 end
 
 @testset "collectscalars" begin
@@ -66,6 +84,15 @@ end
     real_itr = (i == 1 ? 1.5 : i for i in itr)
     @test collect_columns(real_itr) == collect(real_itr)
     @test eltype(collect_columns(real_itr)) == Float64
+
+    #empty
+    itr = Iterators.filter(t -> t > 10, 1:8)
+    tuple_itr = (exp(i) for i in itr)
+    @test collect_columns(tuple_itr) == Float64[]
+
+    itr = (i for i in 0:-1)
+    tuple_itr = (exp(i) for i in itr)
+    @test collect_columns(tuple_itr) == Float64[]
 end
 
 @testset "collectpairs" begin
@@ -84,4 +111,13 @@ end
     v = (i == 1 ? @NT(a="1") => @NT(b="a$i") : @NT(a=i) => @NT(b="a$i") for i in 1:3)
     @test collect_columns(v) == Columns(Columns(@NT(a = ["1",2,3]))=>Columns(@NT(b = ["a1","a2","a3"])))
     @test eltype(collect_columns(v)) == Pair{NamedTuples._NT_a{Any}, NamedTuples._NT_b{String}}
+
+    # empty
+    v = (@NT(a=i) => @NT(b="a$i") for i in 0:-1)
+    @test collect_columns(v) == Columns(Columns(@NT(a = Int[]))=>Columns(@NT(b = String[])))
+    @test eltype(collect_columns(v)) == Pair{NamedTuples._NT_a{Int}, NamedTuples._NT_b{String}}
+
+    v = Iterators.filter(t -> t.first.a == 4, (@NT(a=i) => @NT(b="a$i") for i in 1:3))
+    @test collect_columns(v) == Columns(Columns(@NT(a = Int[]))=>Columns(@NT(b = String[])))
+    @test eltype(collect_columns(v)) == Pair{NamedTuples._NT_a{Int}, NamedTuples._NT_b{String}}
 end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -624,6 +624,8 @@ end
     t5 = table([1,2], ["a", "b"], names = [:x, :y])
     s = [:x, :y]
     @test map(i -> Tuple(getfield(i, j) for j in s), t5) == table([1,2], ["a", "b"])
+
+    @test map(t -> (1,2), table(Int[])) == table(Int[], Int[])
 end
 
 @testset "join" begin


### PR DESCRIPTION
It also fixes `map` and `map_rows` as a consequence (as well as the breakage in JuliaDBMeta mentioned in #143 ).