### PR TITLE
Construct table from pairs

### DIFF
--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -209,6 +209,8 @@ function ndsparse(x::Columns, y::AbstractVector; kwargs...)
     ndsparse(columns(x), y; kwargs...)
 end
 
+ndsparse(c::Columns{<:Pair}; kwargs...) =
+    convert(NDSparse, c.columns.first, c.columns.second; kwargs...)
 
 # backwards compat
 NDSparse(idx::Columns, data; kwargs...) = ndsparse(idx, data; kwargs...)

--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -423,6 +423,7 @@ function deserialize(s::AbstractSerializer, ::Type{SerializedNDSparse})
 end
 
 convert(::Type{NDSparse}, ks, vs; kwargs...) = ndsparse(ks, vs; kwargs...)
+convert(T::Type{NDSparse}, c::Columns{<:Pair}; kwargs...) = convert(T, c.columns.first, c.columns.second; kwargs...)
 
 # map and convert
 

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -268,7 +268,7 @@ function map(f, t::Dataset; select=nothing, copy=false, kwargs...)
     end
 
     x = map_rows(f, rows(t, select))
-    isa(x, Columns) ? convert(NextTable, x; copy=false, kwargs...) : x
+    isa(x, Columns) ? table(x; copy=false, kwargs...) : x
 end
 
 function _nonna(t::Union{Columns, NextTable}, by=(colnames(t)...))

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -260,7 +260,7 @@ julia> map(sin, polar, select=:θ)
 """
 function map(f, t::AbstractIndexedTable; select=nothing) end
 
-function map(f, t::Dataset; select=nothing)
+function map(f, t::Dataset; select=nothing, copy=false, kwargs...)
     if isa(f, Tup) && select===nothing
         select = colnames(t)
     elseif select === nothing
@@ -268,7 +268,7 @@ function map(f, t::Dataset; select=nothing)
     end
 
     x = map_rows(f, rows(t, select))
-    isa(x, Columns) ? table(x) : x
+    isa(x, Columns) ? convert(NextTable, x; copy=false, kwargs...) : x
 end
 
 function _nonna(t::Union{Columns, NextTable}, by=(colnames(t)...))

--- a/src/table.jl
+++ b/src/table.jl
@@ -248,6 +248,7 @@ function table(cs::Tup; chunks=nothing, kwargs...)
 end
 
 table(cs::Columns; kwargs...) = table(columns(cs); kwargs...)
+table(c::Columns{<:Pair}; kwargs...) = convert(NextTable, c.columns.first, c.columns.second; kwargs...)
 
 function table(cols::AbstractArray...; names=nothing, kwargs...)
     if isa(names, AbstractArray) && all(x->isa(x, Symbol), names)
@@ -582,10 +583,6 @@ function convert(::Type{NextTable}, key, val; kwargs...)
 end
 
 convert(T::Type{NextTable}, c::Columns{<:Pair}; kwargs...) = convert(T, c.columns.first, c.columns.second; kwargs...)
-convert(::Type{NextTable}, c; kwargs...) = table(c; kwargs...)
-# To prevent ambiguity
-convert(::Type{NextTable}, c::NextTable; kwargs...) = table(c; kwargs...)
-
 # showing
 
 import Base.Markdown.with_output_format

--- a/src/table.jl
+++ b/src/table.jl
@@ -581,6 +581,11 @@ function convert(::Type{NextTable}, key, val; kwargs...)
     table(cs, pkey=[1:ncols(key);]; kwargs...)
 end
 
+convert(T::Type{NextTable}, c::Columns{<:Pair}; kwargs...) = convert(T, c.columns.first, c.columns.second; kwargs...)
+convert(::Type{NextTable}, c; kwargs...) = table(c; kwargs...)
+# To prevent ambiguity
+convert(::Type{NextTable}, c::NextTable; kwargs...) = table(c; kwargs...)
+
 # showing
 
 import Base.Markdown.with_output_format

--- a/src/tabletraits.jl
+++ b/src/tabletraits.jl
@@ -57,23 +57,13 @@ function NDSparse(x; idxcols::Union{Void,Vector{Symbol}}=nothing, datacols::Unio
     end
 end
 
-function table(rows::AbstractArray{T}; kwargs...) where {T<:NamedTuple}
-    source_data, source_names = TableTraitsUtils.create_columns_from_iterabletable(rows, array_factory=_array_factory)
-
-    kwargs_dict = Dict{Symbol,Any}(i[1]=>i[2] for i in kwargs)
-    kwargs_dict[:copy] = false
-
-    return table(source_data..., names=source_names; kwargs_dict...)
+function table(rows::AbstractArray{T}; copy=false, kwargs...) where {T<:Union{Tup, Pair}}
+    convert(NextTable, collect_columns(rows); copy=false, kwargs...)
 end
 
-function table(iter; kwargs...)
-    if isiterabletable(iter)
-        source_data, source_names = TableTraitsUtils.create_columns_from_iterabletable(iter, array_factory=_array_factory)
-
-        kwargs_dict = Dict{Symbol,Any}(i[1]=>i[2] for i in kwargs)
-        kwargs_dict[:copy] = false
-
-        return table(source_data..., names=source_names; kwargs_dict...)
+function table(iter; copy=false, kwargs...)
+    if TableTraits.isiterable(iter)
+        convert(NextTable, collect_columns(getiterator(iter)); copy=false, kwargs...)
     else
         throw(ArgumentError("iter cannot be turned into a NextTable."))
     end

--- a/src/tabletraits.jl
+++ b/src/tabletraits.jl
@@ -58,12 +58,12 @@ function NDSparse(x; idxcols::Union{Void,Vector{Symbol}}=nothing, datacols::Unio
 end
 
 function table(rows::AbstractArray{T}; copy=false, kwargs...) where {T<:Union{Tup, Pair}}
-    convert(NextTable, collect_columns(rows); copy=false, kwargs...)
+    table(collect_columns(rows); copy=false, kwargs...)
 end
 
 function table(iter; copy=false, kwargs...)
     if TableTraits.isiterable(iter)
-        convert(NextTable, collect_columns(getiterator(iter)); copy=false, kwargs...)
+        table(collect_columns(getiterator(iter)); copy=false, kwargs...)
     else
         throw(ArgumentError("iter cannot be turned into a NextTable."))
     end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -624,6 +624,8 @@ end
     t5 = table([1,2], ["a", "b"], names = [:x, :y])
     s = [:x, :y]
     @test map(i -> Tuple(getfield(i, j) for j in s), t5) == table([1,2], ["a", "b"])
+    @test map(i -> (i.x => i.y), t5) == table([1,2], ["a","b"], pkey=1)
+    @test map(i -> (@NT(a = i.x-1)=>@NT(b=i.y)), t5) == table([0,1], ["a","b"], pkey=:a, names=[:a,:b])
 
     @test map(t -> (1,2), table(Int[])) == table(Int[], Int[])
 end
@@ -1016,6 +1018,10 @@ end
     nd[1:5,1:5] = 2
     @test nd == convert(NDSparse, spdiagm(fill(2, 5)))
 
+    a = [1,2,3]
+    b = ["a","b","c"]
+    v = Columns(Pair(a, b))
+    @test convert(NDSparse, a, b) == convert(NDSparse, v) == NDSparse(a, b)
 end
 
 @testset "mapslices" begin

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -1021,7 +1021,7 @@ end
     a = [1,2,3]
     b = ["a","b","c"]
     v = Columns(Pair(a, b))
-    @test convert(NDSparse, a, b) == convert(NDSparse, v) == NDSparse(a, b)
+    @test convert(NDSparse, a, b) == convert(NDSparse, v) == ndsparse(v) == ndsparse(a, b)
 end
 
 @testset "mapslices" begin

--- a/test/test_tabletraits.jl
+++ b/test/test_tabletraits.jl
@@ -69,4 +69,9 @@ it4 = table(as_set, copy=true)
             table(["A", "A"], names = [:col1], pkey = [1])
 end
 
+# Non NamedTuples iterators
+
+@test table([(1, 2), (3, 4)]) == table([1, 3], [2, 4])
+@test table([@NT(a=1) => @NT(b=2)]) == table([1], [2], names = [:a, :b], pkey = :a)
+
 end


### PR DESCRIPTION
This adds constructors and conversion methods to construct a `NextTable` or `NDSparse` from `Columns{<:Pair}` objects (the `first` field of the pair corresponding to primary keys), generalizes the iterator method for `table` to also accept iterators of tuples or pairs (in which case the `first` columns are primary, you can specify `presorted = true` if you know already they will be sorted).

`map` also allows functions that output a `Pair`, in which case the resulting table will have primary keys.

I think this should be the last tool needed to port `groupreduce` to the new `collect_columns` based implementation.