### PR TITLE
Remove Series wrappers for OnlineStats

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.6
 Compat 0.19
 NamedTuples 2.1.0
-OnlineStats v0.15.0
+OnlineStats 0.17
 PooledArrays
 TableTraits 0.0.1
 TableTraitsUtils 0.0.1

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -1149,14 +1149,14 @@ renamecol(t, name, newname) = @cols rename!(t, name, newname)
 
 using OnlineStats
 
-@inline _apply(f::OnlineStats.AbstractSeries, g, x) = (fit!(g, x); g)
+@inline _apply(f::OnlineStat, g, x) = (fit!(g, x); g)
 @inline _apply(f::Tup, y::Tup, x::Tup) = map(_apply, f, y, x)
 @inline _apply(f, y, x) = f(y, x)
 @inline _apply(f::Tup, x::Tup) = map(_apply, f, x)
 @inline _apply(f, x) = f(x)
 
 @inline init_first(f, x) = x
-@inline init_first(f::OnlineStats.AbstractSeries, x) = (g=copy(f); fit!(g, x); g)
+@inline init_first(f::OnlineStat, x) = (g=copy(f); fit!(g, x); g)
 @inline init_first(f::Tup, x::Tup) = map(init_first, f, x)
 
 # Initialize type of output, functions to apply, input and output vectors
@@ -1173,15 +1173,11 @@ function reduced_type(f, x, isvec, key = nothing)
 end
 
 function init_inputs(f, x, gettype, isvec) # normal functions
-    g = f isa OnlineStat ? Series(f) : f
-    g, x, gettype(g, x, isvec)
+    f, x, gettype(f, x, isvec)
 end
 
 nicename(f) = Symbol(f)
 nicename(o::OnlineStat) = Symbol(typeof(o).name.name)
-function nicename(s::OnlineStats.AbstractSeries)
-    Symbol(join(nicename.(stats(s)), :_))
-end
 
 function mapped_type(f, x, isvec)
     _promote_op(f, eltype(x))
@@ -1212,7 +1208,7 @@ function init_funcs(f::Tup, isvec)
     ns = map(x->x[1], funcmap)
     ss = map(x->x[2], funcmap)
     fs = map(map(x->x[3], funcmap)) do f
-        f isa OnlineStat ? Series(f) : f
+        f
     end
 
     namedtuple(ns...)(fs...), ss

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -45,10 +45,7 @@ If `f` is an OnlineStat object from the [OnlineStats](https://github.com/joshday
 julia> using OnlineStats
 
 julia> reduce(Mean(), t, select=:t)
-▦ Series{0,Tuple{Mean},EqualWeight}
-┣━━ EqualWeight(nobs = 3)
-┗━━━┓
-    ┗━━ Mean(0.45)
+Mean: n=3 | value=0.45
 ```
 
 # Reducing with multiple functions
@@ -80,25 +77,13 @@ You can also compute many OnlineStats by passing tuple or named tuple of OnlineS
 
 ```jldoctest reduce
 julia> y = reduce((Mean(), Variance()), t, select=:t)
-(Mean = ▦ Series{0,Tuple{Mean},EqualWeight}
-┣━━ EqualWeight(nobs = 3)
-┗━━━┓
-    ┗━━ Mean(0.45), Variance = ▦ Series{0,Tuple{Variance},EqualWeight}
-┣━━ EqualWeight(nobs = 3)
-┗━━━┓
-    ┗━━ Variance(0.1075))
+(Mean = Mean: n=3 | value=0.45, Variance = Variance: n=3 | value=0.1075)
 
 julia> y.Mean
-▦ Series{0,Tuple{Mean},EqualWeight}
-┣━━ EqualWeight(nobs = 3)
-┗━━━┓
-    ┗━━ Mean(0.45)
+Mean: n=3 | value=0.45
 
 julia> y.Variance
-▦ Series{0,Tuple{Variance},EqualWeight}
-┣━━ EqualWeight(nobs = 3)
-┗━━━┓
-    ┗━━ Variance(0.1075)
+Variance: n=3 | value=0.1075
 ```
 
 # Combining reduction and selection

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -838,7 +838,7 @@ end
     t = table([0.1, 0.5, 0.75], [0, 1, 2], names=[:t, :x])
     @test reduce(+, t, select=:t) == 1.35
     @test reduce(((a, b)->@NT(t = a.t + b.t, x = a.x + b.x)), t) == @NT(t = 1.35, x = 3)
-    @test value(reduce(Mean(), t, select=:t)) == (0.45,)
+    @test value(reduce(Mean(), t, select=:t)) == 0.45
     y = reduce((min, max), t, select=:x)
     @test y.max == 2
     @test y.min == 0
@@ -846,8 +846,8 @@ end
     x = select(t, :x)
     @test y == @NT(sum = sum(x), prod = prod(x))
     y = reduce((Mean(), Variance()), t, select=:t)
-    @test value(y.Mean) == (0.45,)
-    @test value(y.Variance) == (0.10749999999999998,)
+    @test value(y.Mean) == 0.45
+    @test value(y.Variance) == 0.10749999999999998
     @test reduce(@NT(xsum = (:x => (+)), negtsum = ((:t => (-)) => (+))), t) == @NT(xsum = 3, negtsum = -1.35)
 end
 


### PR DESCRIPTION
Now that we have new releases of OnlineStats[Base], we no longer need to wrap stats in a Series.  