### PR TITLE
More collect_column fixes

### DIFF
--- a/src/collect.jl
+++ b/src/collect.jl
@@ -4,6 +4,14 @@ _is_subtype(::Type{S}, ::Type{T}) where {S, T} = S <: T
 _is_subtype(::Type{S}, ::Type{DataValue{T}}) where {S, T} = S<:T
 _is_subtype(::Type{DataValue{S}}, ::Type{DataValue{T}}) where {S, T} = S<:T
 
+Base.@pure function dataarrayof(T)
+    if T<:DataValue
+        DataValueArray{T.parameters[1],1}
+    else
+        Vector{T}
+    end
+end
+
 """
 `collect_columns(itr)`
 
@@ -125,7 +133,7 @@ function widencolumns(dest, i, el::S, ::Type{T}) where{S <: Tup, T<:Tup}
         idx = find(!(s <: t) for (s, t) in zip(sp, tp))
         new = dest
         for l in idx
-            newcol = Array{promote_type(sp[l], tp[l])}(length(dest))
+            newcol = dataarrayof(promote_type(sp[l], tp[l]))(length(dest))
             copy!(newcol, 1, column(dest, l), 1, i-1)
             new = setcol(new, l, newcol)
         end
@@ -134,7 +142,7 @@ function widencolumns(dest, i, el::S, ::Type{T}) where{S <: Tup, T<:Tup}
 end
 
 function widencolumns(dest, i, el::S, ::Type{T}) where{S, T}
-    new = Array{promote_type(S, T)}(length(dest))
+    new = dataarrayof(promote_type(S, T))(length(dest))
     copy!(new, 1, dest, 1, i-1)
     new
 end

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -1,8 +1,6 @@
 import DataValues: DataValue
 
-_is_subtype(::Type{S}, ::Type{T}) where {S, T} = S <: T
-_is_subtype(::Type{S}, ::Type{DataValue{T}}) where {S, T} = S<:T
-_is_subtype(::Type{DataValue{S}}, ::Type{DataValue{T}}) where {S, T} = S<:T
+_is_subtype(::Type{S}, ::Type{T}) where {S, T} = promote_type(S, T) == T
 
 Base.@pure function dataarrayof(T)
     if T<:DataValue

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -93,6 +93,10 @@ end
     itr = (i for i in 0:-1)
     tuple_itr = (exp(i) for i in itr)
     @test collect_columns(tuple_itr) == Float64[]
+
+    t = collect_columns(@NT(a = i) for i in (1, DataValue{Int}(), 3))
+    @test columns(t, 1) isa DataValueArray
+    @test isequal(columns(t, 1), DataValueArray([1, DataValue{Int}(), 3]))
 end
 
 @testset "collectpairs" begin


### PR DESCRIPTION
Correct function to choose whether to widen correctly in all cases, correctly create `DataValueArray` even if column starts as regular `Array` but widens later.