### PR TITLE
WIP/RFC: collect_columns_flattened

### DIFF
--- a/src/collect.jl
+++ b/src/collect.jl
@@ -91,6 +91,10 @@ function collect_columns_flattened(itr, el, st)
         el, st = next(itr, st)
     end
     dest = collect_columns(el)
+    collect_columns_flattened!(dest, itr, el, st)
+end
+
+function collect_columns_flattened!(dest, itr, el, st)
     while !done(itr, st)
         el, st = next(itr, st)
         dest = grow_to_columns!(dest, el)
@@ -105,11 +109,16 @@ function collect_columns_flattened(itr, el::Pair, st)
     end
     dest_data = collect_columns(el.second)
     dest_key = collect_columns(el.first for i in dest_data)
+    collect_columns_flattened!(Columns(dest_key => dest_data), itr, el, st)
+end
+
+function collect_columns_flattened!(dest::Columns{<:Pair}, itr, el::Pair, st)
+    dest_key, dest_data = dest.columns
     while !done(itr, st)
         el, st = next(itr, st)
         n = length(dest_data)
-        dest_data = grow_to_columns!(dest_data, el)
-        dest_key = grow_to_columns!(dest_data, el.first for i in (n+1):length(dest_data))
+        dest_data = grow_to_columns!(dest_data, el.second)
+        dest_key = grow_to_columns!(dest_key, el.first for i in (n+1):length(dest_data))
     end
     return Columns(dest_key => dest_data)
 end

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -1,3 +1,5 @@
+using IndexedTables: collect_columns_flattened
+
 @testset "collectnamedtuples" begin
     v = [@NT(a = 1, b = 2), @NT(a = 1, b = 3)]
     @test collect_columns(v) == Columns(@NT(a = Int[1, 1], b = Int[2, 3]))

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -137,3 +137,13 @@ end
     @test !IndexedTables._is_subtype(DataValue{Int}, DataValue{String})
     @test !IndexedTables._is_subtype(Int, String)
 end
+
+@testset "collectflattened" begin
+    t = [(:a => [1, 2]), (:b => [1, 3])]
+    @test collect_columns_flattened(t) == Columns([:a, :a, :b, :b] => [1, 2, 1, 3])
+    t = ([@NT(a = 1), @NT(a = 2)], [@NT(a = 1.1), @NT(a = 2.2)])
+    @test collect_columns_flattened(t) == Columns(a = [1, 2, 1.1, 2.2])
+    @test eltype(collect_columns_flattened(t)) == typeof(@NT(a=1.1))
+    t = [(:a => table(1:2, ["a", "b"])), (:b => table(3:4, ["c", "d"]))]
+    @test table(collect_columns_flattened(t)) == table([:a, :a, :b, :b], 1:4, ["a", "b", "c", "d"], pkey = 1)
+end


### PR DESCRIPTION
I'm adding a method to flatten and collect an iterator as `Columns`. It will be useful to optimize `groupby` with `flatten=true` (it will be done with just one pass over the data and the user will be able to save some allocations if the function in `groupby` returns an iterable rather than a table). I'm also needing it to convert `join` to the iterator approach.

It can either flatten an iterable of iterables or an iterable of pairs, where each pair is `key => iterable`.

Ideally it should have all the features of `flatten` and I hope could replace it eventually, but I'm not 100% sure what else `flatten` does other than flattening (in terms of naming or repeated keys).

I'm also not sure whether we want `collect_columns(x; flatten = false)`, it's handy but it seems we lose inferrability (though maybe that's fine). We could also want a "gentle" version that only flattens when it make sence (which could potentially be the one implemented as `collect_columns(x; flatten = false)`. The regular `flatten` checks that elements are iterable before attempting to flatten.