### PR TITLE
Add method to collect iterator of pairs as `ndsparse`

### DIFF
--- a/src/columns.jl
+++ b/src/columns.jl
@@ -632,6 +632,14 @@ end
 
 const SpecialSelector = Union{Not, All, Keys, Between, Function, Regex}
 
+hascolumns(t, s) = true
+hascolumns(t, s::Symbol) = s in colnames(t)
+hascolumns(t, s::Int) = s in 1:length(columns(t))
+hascolumns(t, s::Tuple) = all(hascolumns(t, x) for x in s)
+hascolumns(t, s::Not) = hascolumns(t, s.cols)
+hascolumns(t, s::Between) = hascolumns(t, s.first) && hascolumns(t, s.last)
+hascolumns(t, s::All) = all(hascolumns(t, x) for x in s.cols)
+
 lowerselection(t, s)                     = s
 lowerselection(t, s::Union{Int, Symbol}) = colindex(t, s)
 lowerselection(t, s::Tuple)              = map(x -> lowerselection(t, x), s)

--- a/src/tabletraits.jl
+++ b/src/tabletraits.jl
@@ -18,44 +18,41 @@ function _array_factory(t,rows)
     end
 end
 
-function NDSparse(x; idxcols::Union{Void,Vector{Symbol}}=nothing, datacols::Union{Void,Vector{Symbol}}=nothing)
-    if isiterabletable(x)
-        iter = getiterator(x)
+function ndsparse(x; idxcols=nothing, datacols=nothing, copy=false, kwargs...)
+    if isiterable(x)
+        source_data = collect_columns(getiterator(x))
+        source_colnames = colnames(source_data)
 
-        source_colnames = TableTraits.column_names(iter)
+        source_colnames isa Pair && return ndsparse(source_data; copy=false, kwargs...)
 
-        if idxcols==nothing && datacols==nothing
-            idxcols = source_colnames[1:end-1]
-            datacols = [source_colnames[end]]
-        elseif idxcols==nothing
-            idxcols = setdiff(source_colnames,datacols)
-        elseif datacols==nothing
-            datacols = setdiff(source_colnames, idxcols)
+        n = length(source_colnames)
+        # For backward compatibility
+        idxcols isa AbstractArray && (idxcols = Tuple(idxcols))
+        datacols isa AbstractArray && (datacols = Tuple(datacols))
+
+        if idxcols==nothing
+            idxcols = (datacols==nothing) ? Between(1, n-1) : Not(datacols)
+        end
+        if datacols==nothing
+            datacols = Not(idxcols)
         end
 
-        if length(setdiff(idxcols, source_colnames))>0
-            error("Unknown idxcol")
-        end
+        hascolumns(source_data, idxcols) || error("Unknown idxcol")
+        hascolumns(source_data, datacols) || error("Unknown datacol")
 
-        if length(setdiff(datacols, source_colnames))>0
-            error("Unknown datacol")
-        end
+        idx_storage = rows(source_data, idxcols)
+        data_storage = rows(source_data, datacols)
 
-        source_data, source_names = TableTraitsUtils.create_columns_from_iterabletable(x, array_factory=_array_factory)
-
-        idxcols_indices = [findfirst(source_colnames,i) for i in idxcols]
-        datacols_indices = [findfirst(source_colnames,i) for i in datacols]
-
-        idx_storage = Columns(source_data[idxcols_indices]..., names=source_colnames[idxcols_indices])
-        data_storage = Columns(source_data[datacols_indices]..., names=source_colnames[datacols_indices])
-
-        return NDSparse(idx_storage, data_storage)
+        return convert(NDSparse, idx_storage, data_storage; copy=false, kwargs...)
     elseif idxcols==nothing && datacols==nothing
-        return convert(NDSparse, x)
+        return convert(NDSparse, x, copy = copy, kwargs...)
     else
         throw(ArgumentError("x cannot be turned into an NDSparse."))
     end
 end
+
+# For backward compatibility
+NDSparse(x; kwargs...) = ndsparse(x; kwargs...)
 
 function table(rows::AbstractArray{T}; copy=false, kwargs...) where {T<:Union{Tup, Pair}}
     table(collect_columns(rows); copy=false, kwargs...)

--- a/src/tabletraits.jl
+++ b/src/tabletraits.jl
@@ -21,16 +21,14 @@ end
 function ndsparse(x; idxcols=nothing, datacols=nothing, copy=false, kwargs...)
     if isiterable(x)
         source_data = collect_columns(getiterator(x))
-        source_colnames = colnames(source_data)
+        source_data isa Columns{<:Pair} && return ndsparse(source_data; copy=false, kwargs...)
 
-        source_colnames isa Pair && return ndsparse(source_data; copy=false, kwargs...)
-
-        n = length(source_colnames)
         # For backward compatibility
         idxcols isa AbstractArray && (idxcols = Tuple(idxcols))
         datacols isa AbstractArray && (datacols = Tuple(datacols))
 
         if idxcols==nothing
+            n = ncols(source_data)
             idxcols = (datacols==nothing) ? Between(1, n-1) : Not(datacols)
         end
         if datacols==nothing

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -3,7 +3,7 @@ using IndexedTables
 using PooledArrays
 using NamedTuples
 using DataValues
-import IndexedTables: update!, pkeynames, pkeys, excludecols, sortpermby, primaryperm, best_perm_estimate
+import IndexedTables: update!, pkeynames, pkeys, excludecols, sortpermby, primaryperm, best_perm_estimate, hascolumns
 
 let c = Columns([1,1,1,2,2], [1,2,4,3,5]),
     d = Columns([1,1,2,2,2], [1,3,1,4,5]),
@@ -770,6 +770,22 @@ end
     @test columns(t, Between(:x, :z)) == columns(t, (:x, :y, :z))
     @test columns(t, i -> i == :y) == columns(t, (:y,))
     @test columns(t, r"x|z") == columns(t, (:x, :z))
+
+    @test hascolumns(t, 1)
+    @test !hascolumns(t, 10)
+    @test hascolumns(t, :x)
+    @test !hascolumns(t, :xx)
+    @test !hascolumns(t, (:xx, :y))
+    @test hascolumns(t, Keys())
+    @test hascolumns(t, (Keys(), :y))
+    @test hascolumns(t, Not(Keys()))
+    @test !hascolumns(t, Not(Keys(), :xx))
+    @test hascolumns(t, All(Keys(), :y))
+    @test hascolumns(t, All())
+    @test hascolumns(t, Between(:x, :z))
+    @test !hascolumns(t, Between(:x, :xx))
+    @test hascolumns(t, i -> i == :y)
+    @test hascolumns(t, r"x|z")
 end
 
 @testset "dropna" begin

--- a/test/test_tabletraits.jl
+++ b/test/test_tabletraits.jl
@@ -36,6 +36,11 @@ it3 = NDSparse(source_array, datacols=[:b, :c])
 @test it3[2] == @NT(b=2., c="B")
 @test it3[3] == @NT(b=3., c="C")
 
+it4 = NDSparse([(1=>"A"), (2=>"B")])
+@test length(it4) == 2
+@test it4[1] == "A"
+@test it4[2] == "B"
+
 source_nt = table([1,2,3],[1.,2.,3.],["A","B","C"], names=[:a,:b,:c])
 
 target_array_nt = collect(getiterator(source_nt))


### PR DESCRIPTION
Now `ndsparse` can accept an iterator of pairs and will build the corresponding `NDSparse` object. As with `table`, I've changed the default collection of iterator mechanism to use `collect_columns`. I'm also allowing the specification of index and data columns to be done with any selector / special selector, rather than just vector of symbols.

I've added `hascolumns` to check that extracting columns with a special selector will not error due to columns not being there (before it was `lenght(setdiff(idxcols, colnames(t))) > 0`, but this doesn't work for a general selector).