### PR TITLE
Column modification usability improvement

### DIFF
--- a/src/columns.jl
+++ b/src/columns.jl
@@ -1001,7 +1001,7 @@ false
 
 ```
 """
-setcol(t, col, x) = @cols setindex!(t, x, col)
+setcol(t, col::Union{Int, Symbol}, x) = @cols setindex!(t, x, col)
 
 """
 `pushcol(t, name, x)`
@@ -1027,7 +1027,7 @@ t     x  y  z
 
 ```
 """
-pushcol(t, name, x) = @cols push!(t, name, x)
+pushcol(t, name::Union{Int, Symbol}, x) = @cols push!(t, name, x)
 
 """
 `popcol(t, col)`
@@ -1050,8 +1050,10 @@ t     y
 0.05  4
 ```
 """
-popcol(t, name) = @cols pop!(t, name)
+popcol(t, name::Union{Int, Symbol}) = @cols pop!(t, name)
 
+popcol(t, args) = foldl(popcol, t, args)
+popcol(t, args::Vararg{Union{Int, Symbol}}) = popcol(t, args)
 """
 `insertcol(t, position::Integer, name, x)`
 
@@ -1143,7 +1145,15 @@ time  x
 0.05  1
 ```
 """
-renamecol(t, name, newname) = @cols rename!(t, name, newname)
+renamecol(t, name::Union{Int, Symbol}, newname) = @cols rename!(t, name, newname)
+
+for s in [:pushcol, :renamecol, :setcol]
+    @eval begin
+        $s(t, p::Pair) = $s(t, p.first, p.second)
+        $s(t, args) = foldl($s, t, args)
+        $s(t, args::Vararg{Pair}) = $s(t, args)
+    end
+end
 
 ## Utilities for mapping and reduction with many functions / OnlineStats
 

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -847,7 +847,7 @@ function Base.setindex!(d::ColDict, x, key::Union{Symbol, Int})
     end
 end
 
-setcol!(d::ColDict, key::Union{Symbol, Int}, x) = setindex!(d, x, key)
+set!(d::ColDict, key::Union{Symbol, Int}, x) = setindex!(d, x, key)
 
 function Base.haskey(d::ColDict, key)
     _colindex(d.names, key, 0) != 0
@@ -883,7 +883,7 @@ function insertbefore!(d::ColDict, i, key, col)
     insert!(d, k, key, col)
 end
 
-function Base.pop!(d::ColDict, key::Union{Symbol, Int}=length(s.names))
+function Base.pop!(d::ColDict, key::Union{Symbol, Int}=length(d.names))
     k = _colindex(d.names, key, 0)
     local col
     if k == 0
@@ -920,7 +920,7 @@ function Base.push!(d::ColDict, key::Union{Symbol, Int}, x)
     push!(d.columns, rows(d.src, x))
 end
 
-for (s, typ) in zip([:(Base.pop!), :(Base.push!), :(rename!), :(setcol!)], [:(Union{Symbol, Int}), :Pair, :Pair, :Pair])
+for (s, typ) in zip([:(Base.pop!), :(Base.push!), :(rename!), :(set!)], [:(Union{Symbol, Int}), :Pair, :Pair, :Pair])
     if s != :(Base.pop!)
         @eval $s(t::ColDict, x::Pair) = $s(t, x.first, x.second)
     end
@@ -1017,7 +1017,7 @@ false
 
 ```
 """
-setcol(t, args...) = @cols setcol!(t, args...)
+setcol(t, args...) = @cols set!(t, args...)
 
 """
 `pushcol(t, name, x)`

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -4,7 +4,7 @@ import Base:
     linearindexing, push!, size, sort, sort!, permute!, issorted, sortperm,
     summary, resize!, vcat, serialize, deserialize, append!, copy!, view
 
-export Columns, colnames, ncols, ColDict, insertafter!, insertbefore!, @cols, setcol, pushcol, popcol, insertcol, insertcolafter, insertcolbefore, renamecol
+export Columns, colnames, ncols, ColDict, insertafter!, insertbefore!, @cols, setcol, pushcol, popcol, insertcol, insertcolafter, insertcolbefore, renamecol, transformcol
 export map_rows
 export All, Not, Between, Keys
 
@@ -1029,6 +1029,11 @@ t     x  y  z
 """
 pushcol(t, name::Union{Int, Symbol}, x) = @cols push!(t, name, x)
 
+function transformcol(t, name::Union{Int, Symbol}, x)
+    i = _colindex(colnames(t), name, 0)
+    i == 0 ? pushcol(t, name, x) : setcol(t, i, x)
+end
+
 """
 `popcol(t, col)`
 
@@ -1147,7 +1152,7 @@ time  x
 """
 renamecol(t, name::Union{Int, Symbol}, newname) = @cols rename!(t, name, newname)
 
-for s in [:pushcol, :renamecol, :setcol]
+for s in [:pushcol, :renamecol, :setcol, :transformcol]
     @eval begin
         $s(t, p::Pair) = $s(t, p.first, p.second)
         $s(t, args) = foldl($s, t, args)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -542,14 +542,23 @@ end
 @testset "column manipulation" begin
     t = table([1, 2], [3, 4], names=[:x, :y])
     @test setcol(t, 2, [5, 6]) == table([1, 2], [5, 6], names=Symbol[:x, :y])
+    @test setcol(t, 2 => [5, 6]) == setcol(t, 2, [5, 6])
+    @test setcol(t, 2 => [5, 6], 1 => [7, 12]) == table([7, 12], [5, 6], names=Symbol[:x, :y]) ==
+        setcol(t, (2 => [5, 6], 1 => [7, 12]))
     @test setcol(t, :x, :x => (x->1 / x)) == table([1.0, 0.5], [3, 4], names=Symbol[:x, :y])
     t = table([0.01, 0.05], [1, 2], [3, 4], names=[:t, :x, :y], pkey=:t)
     t2 = setcol(t, :t, [0.1, 0.05])
     @test t2 == table([0.05, 0.1], [2,1], [4,3], names=[:t,:x,:y])
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t)
     @test pushcol(t, :z, [1 // 2, 3 // 4]) == table([0.01, 0.05], [2, 1], [3, 4], [1//2, 3//4], names=Symbol[:t, :x, :y, :z])
+    @test pushcol(t, :z => [1 // 2, 3 // 4]) == pushcol(t, :z, [1 // 2, 3 // 4])
+    @test pushcol(t, :z => [1 // 2, 3 // 4], :w => [0, 1]) ==
+        table([0.01, 0.05], [2, 1], [3, 4], [1//2, 3//4], [0, 1], names=Symbol[:t, :x, :y, :z, :w]) ==
+        pushcol(t, (:z => [1 // 2, 3 // 4], :w => [0, 1]))
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=(:t,:x))
     @test popcol(t, :t) == table([1, 2], [4,3], names=Symbol[:x, :y])
+    @test popcol(t) == table([0.01, 0.05], [2, 1], names=Symbol[:t, :x])
+    @test popcol(t, :x, :y) == table([0.01, 0.05], names=Symbol[:t]) == popcol(t, (:x, :y))
     @test pushcol(t, :z, [1 // 2, 3 // 4]) == table([0.01, 0.05], [2, 1], [3, 4], [1//2, 3//4], names=Symbol[:t, :x, :y, :z])
 
     # 99
@@ -584,6 +593,10 @@ end
     t = table([0.01, 0.05], [2, 1], names=[:t, :x])
     @test renamecol(t, :t, :time) == table([0.01, 0.05], [2, 1], names=Symbol[:time, :x])
     @test_throws ErrorException renamecol(t, :tt, :time)
+    @test renamecol(t, :t => :time) == renamecol(t, :t, :time)
+    @test renamecol(t, :t => :time, :x => :position) ==
+        table([0.01, 0.05], [2, 1], names=Symbol[:time, :position]) ==
+        renamecol(t, (:t => :time, :x => :position))
 end
 
 @testset "map" begin


### PR DESCRIPTION
Still lacks docs and tests but I was wondering if it is something people find useful. The strategy is:

- For column modificators that take two arguments other than the table (name and value or name and new name) add a `Pair` option, i. e. `setcol(t, name => value)`
- Add iterator version `setcol(t, itr) = foldl(setcol, t, itr)` as well as `setcol(t, itr...)` with the same meaning
- Add `transformcol` that combines `setcol` and `pushcol`: modify a column if it exists, add it otherwise. I have it implemented in JuliaDBMeta but I thought it made sense to have it here.

Example usage:

```julia
julia> t = table(rand(10), rand(10), rand(10), names = [:a, :b, :c]);

julia> renamecol(t, :a => :aa, :b => :bb)
Table with 10 rows, 3 columns:
aa        bb         c
─────────────────────────────
0.163642  0.0324896  0.117211
0.926122  0.102359   0.560399
0.917097  0.590855   0.325438
0.215478  0.734164   0.77882
0.594439  0.702912   0.609979
0.812428  0.757228   0.627404
0.804359  0.621889   0.17073
0.510328  0.387981   0.673884
0.593012  0.591315   0.290553
0.892289  0.486617   0.142943

# Can also take iterable
julia> setcol(t, (:a => fill(1, 10), :b => fill(1, 10)))
Table with 10 rows, 3 columns:
a  b  c
──────────────
1  1  0.117211
1  1  0.560399
1  1  0.325438
1  1  0.77882
1  1  0.609979
1  1  0.627404
1  1  0.17073
1  1  0.673884
1  1  0.290553
1  1  0.142943

julia> transformcol(t, :a => fill(1, 10), :d => fill(1, 10))
Table with 10 rows, 4 columns:
a  b          c         d
─────────────────────────
1  0.0324896  0.117211  1
1  0.102359   0.560399  1
1  0.590855   0.325438  1
1  0.734164   0.77882   1
1  0.702912   0.609979  1
1  0.757228   0.627404  1
1  0.621889   0.17073   1
1  0.387981   0.673884  1
1  0.591315   0.290553  1
1  0.486617   0.142943  1
```