### PR TITLE
optimize `permute!` for certain data types

### DIFF
--- a/src/columns.jl
+++ b/src/columns.jl
@@ -314,10 +314,7 @@ end
 
 function permute!(c::Columns, p::AbstractVector)
     for v in c.columns
-        if isa(v, StringArray{String})
-            ws = convert(StringArray{WeakRefString{UInt8}}, v)
-            permute!(ws, p)
-        elseif isa(v, PooledArrays.PooledArray)
+        if isa(v, PooledArrays.PooledArray) || isa(v, StringArray{String})
             permute!(v, p)
         else
             copy!(v, v[p])

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -314,7 +314,14 @@ end
 
 function permute!(c::Columns, p::AbstractVector)
     for v in c.columns
-        copy!(v, v[p])
+        if isa(v, StringArray{String})
+            ws = convert(StringArray{WeakRefString{UInt8}}, v)
+            permute!(ws, p)
+        elseif isa(v, PooledArrays.PooledArray)
+            permute!(v, p)
+        else
+            copy!(v, v[p])
+        end
     end
     return c
 end


### PR DESCRIPTION
Optimize `permute!` of columns of types `StringVector{String}` and `PooledArray`

Without this change:

```
julia> using IndexedTables, WeakRefStrings, PooledArrays, BenchmarkTools

julia> sv = StringVector{String}(convert(Vector{UInt8}, randstring(10^6+10)), UInt64[1:10:10^6;], ones(UInt32,10^5)*9);

julia> pv = PooledArray([randstring(5) for idx in 1:10^5]);

julia> cs = Columns(@NT(s=sv));

julia> cp = Columns(@NT(a=pv));

julia> p = randperm(10^5);

julia> @btime permute!(cs, p);
  9.412 ms (200025 allocations: 9.50 MiB)

julia> @btime permute!(cp, p);
  31.896 ms (199530 allocations: 12.54 MiB)
```

With this change:

```
julia> @btime permute!(cs, p);
  1.553 ms (3 allocations: 781.36 KiB)

julia> @btime permute!(cp, p);
  1.454 ms (2 allocations: 781.33 KiB)
```