### PR TITLE
keep merged columns as PooledArrays when possible

### DIFF
--- a/src/join.jl
+++ b/src/join.jl
@@ -874,8 +874,12 @@ function Base.merge(a::NextTable, b::NextTable;
     else
         throw(ArgumentError("the tables don't have the same column names. Use `select` first."))
     end
-    table(map(vcat, columns(a), columns(b)), pkey=pkey, copy=false)
+    table(map(opt_vcat, columns(a), columns(b)), pkey=pkey, copy=false)
 end
+
+opt_vcat(a, b) = vcat(a, b)
+opt_vcat(a::AbstractArray{<:Any, 1}, b::PooledArray{<:Any, <:Integer, 1}) = vcat((length(unique(a)) <= length(b.pool)) ? PooledArray(a) : a, b)
+opt_vcat(a::PooledArray{<:Any, <:Integer, 1}, b::AbstractArray{<:Any, 1}) = vcat(a, (length(unique(b)) < length(a.pool)) ? PooledArray(b) : b)
 
 function merge(x::NDSparse, xs::NDSparse...; agg = nothing)
     as = [x, xs...]

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -857,6 +857,24 @@ end
     b = ndsparse([2, 3, 4], [1, 2, 3])
     @test merge(a, b) == ndsparse(([1, 2, 3, 4, 5],), [1, 1, 2, 3, 3])
     @test merge(a, b, agg=+) == ndsparse(([1, 2, 3, 4, 5],), [1, 1, 4, 3, 3])
+
+    # merge optimization for pooled arrays
+    x = begin
+        x = [randstring(5) for idx in 1:128];
+        for idx in 1:5
+            x = vcat(x, x)
+        end
+        PooledArray(x)
+    end;
+    a = table(x, names=[:x]);
+    b = table([randstring(5) for idx in 1:64], names=[:x]);
+    c = merge(a, b);
+    d = merge(b, a);
+
+    @test isa(select(a, :x), PooledArray)
+    @test !isa(select(b, :x), PooledArray)
+    @test isa(select(c, :x), PooledArray)
+    @test isa(select(d, :x), PooledArray)
 end
 
 @testset "broadcast" begin


### PR DESCRIPTION
The default merge behavior of PooledArray is to always convert the result to a non pooled type.

This overrides that behavior when the non pooled column is of reasonable length.