### PR TITLE
Add stack option for summarize

### DIFF
--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -998,6 +998,15 @@ end
     b = table(["a","a","b","b"], [1,3,5,7], [2,2,2,2], names = [:x, :y, :z], pkey = :x)
     @test summarize(mean, b) ==
         table(["a","b"], [2.0,6.0], [2.0,2.0], names = [:x, :y, :z], pkey = :x)
+    @test summarize((mean, std), a, stack = true) ==
+        table([:x, :y], [3.0, 2.0], [2.0, 0.0], names = [:variable, :mean, :std])
+    @test summarize(mean, a, stack = true) ==
+        table([:x, :y], [3.0, 2.0] names = [:variable, :mean])
+    @test summarize(mean, b, stack = true) ==
+        table(["a","a","b","b"], [:y,:z,:y,:z], [2.0,2.0,6.0,2.0], names = [:x, :variable, :mean], pkey = :x)
+    @test summarize((mean, sum), b, stack = true) ==
+        table(["a","a","b","b"], [:y,:z,:y,:z], [2.0,2.0,6.0,2.0], [4,4,12,4],
+        names = [:x, :variable, :mean, :sum], pkey = :x)
 end
 
 @testset "reshape" begin

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -1001,7 +1001,7 @@ end
     @test summarize((mean, std), a, stack = true) ==
         table([:x, :y], [3.0, 2.0], [2.0, 0.0], names = [:variable, :mean, :std])
     @test summarize(mean, a, stack = true) ==
-        table([:x, :y], [3.0, 2.0] names = [:variable, :mean])
+        table([:x, :y], [3.0, 2.0], names = [:variable, :mean])
     @test summarize(mean, b, stack = true) ==
         table(["a","a","b","b"], [:y,:z,:y,:z], [2.0,2.0,6.0,2.0], names = [:x, :variable, :mean], pkey = :x)
     @test summarize((mean, sum), b, stack = true) ==


### PR DESCRIPTION
Based on [this thread](https://discourse.julialang.org/t/a-proposal-for-describe-of-a-dataframe/10254) in discourse: it allows a "stacked" version of summarize, which can be practical in some cases:

```julia
julia> t = table([1,2,3], [4,5,6], rand(3), names = [:a,:b,:c])
Table with 3 rows, 3 columns:
a  b  c
───────────────
1  4  0.171499
2  5  0.0396722
3  6  0.360162

julia> summarize((mean, std, eltype), t, stack=true)
Table with 3 rows, 4 columns:
variable  mean      std       eltype
─────────────────────────────────────
:a        2.0       1.0       Int64
:b        5.0       1.0       Int64
:c        0.190444  0.161083  Float64
```
