### PR TITLE
keep WeakRefString in StringArray instead of Array

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -252,7 +252,7 @@ Base.@pure function arrayof(S)
         Columns{T,namedtuple(fieldnames(T)...){map(arrayof, T.parameters)...}}
     elseif T<:DataValue
         DataValueArray{T.parameters[1],1}
-    elseif T<:String
+    elseif T<:Union{String,WeakRefString}
         StringArray{T, 1}
     elseif T<:Pair
         Columns{T, Pair{map(arrayof, T.parameters)...}}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using OnlineStats
 using DataValues
 import DataValues: NA
 using Base.Test
+using WeakRefStrings
 
 @testset "IndexedTables" begin
 

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -41,6 +41,7 @@ let c = Columns(Columns(@NT(a=[1,2,3])) => Columns(@NT(b=["a","b","c"])))
     @test c != Columns(@NT(a=[1,2,3], b=["a","b","c"]))
     x = Columns([1], [1.0], WeakRefStrings.StringArray(["a"]))
     @test IndexedTables.arrayof(eltype(x)) == typeof(x)
+    @test IndexedTables.arrayof(WeakRefString{UInt8}) == WeakRefStrings.StringArray{WeakRefString{UInt8},1}
     @test typeof(similar(c, 10)) == typeof(similar(typeof(c), 10)) == typeof(c)
     @test length(similar(c, 10)) == 10
     @test issorted(c)


### PR DESCRIPTION
to ensure they are serialized properly

fixes https://github.com/JuliaComputing/JuliaDB.jl/issues/198 and https://github.com/JuliaComputing/JuliaDB.jl/issues/199