### PR TITLE
optimize `sortperm` on Columns of StringArrays

### DIFF
--- a/src/columns.jl
+++ b/src/columns.jl
@@ -272,14 +272,14 @@ function sortperm(c::Columns)
     cols = c.columns
     x = cols[1]
     if (eltype(x) <: AbstractString && !(x isa PooledArray)) || length(cols) > 1
-        pa = PooledArray(x)
+        pa = PooledArray(compact_mem(x))
         p = sortperm_fast(pa)
     else
         p = sortperm_fast(x)
     end
     if length(cols) > 1
         y = cols[2]
-        refine_perm!(p, cols, 1, x, y, 1, length(x))
+        refine_perm!(p, cols, 1, compact_mem(x), compact_mem(y), 1, length(x))
     end
     return p
 end
@@ -305,7 +305,7 @@ function refine_perm!(p, cols, c, x, y, lo, hi)
             sort_sub_by!(p, i, i1, y, order, temp)
             if c < nc-1
                 z = cols[c+2]
-                refine_perm!(p, cols, c+1, y, z, i, i1)
+                refine_perm!(p, cols, c+1, compact_mem(y), compact_mem(z), i, i1)
             end
         end
         i = i1+1
@@ -1293,3 +1293,7 @@ function init_inputs(f::Tup, input, gettype, isvec)
     # functions, input, output_eltype
     NT(fs...), rows(NT(xs...)), NT{output_eltypes...}
 end
+
+### utils
+
+compact_mem(x::Columns) = Columns(map(compact_mem, columns(x)))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -391,3 +391,6 @@ function isshared(x)
         end
     end
 end
+
+compact_mem(x) = x
+compact_mem(x::StringArray{String}) = convert(StringArray{WeakRefString{UInt8}}, x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -159,17 +159,17 @@ function sortperm_int_range(x::Vector{T}, rangelen, minval) where T<:Integer
 end
 
 # sort the values in v[i0:i1] in place, by array `by`
-function sort_sub_by!(v, i0, i1, by, order, temp)
+Base.@noinline function sort_sub_by!(v, i0, i1, by, order, temp)
     empty!(temp)
     sort!(v, i0, i1, MergeSort, order, temp)
 end
 
-function sort_sub_by!(v, i0, i1, by::PooledArray, order, temp)
+Base.@noinline function sort_sub_by!(v, i0, i1, by::PooledArray, order, temp)
     empty!(temp)
     sort!(v, i0, i1, MergeSort, order, temp)
 end
 
-function sort_sub_by!(v, i0, i1, by::Vector{T}, order, temp) where T<:Integer
+Base.@noinline function sort_sub_by!(v, i0, i1, by::Vector{T}, order, temp) where T<:Integer
     min = max = by[v[i0]]
     @inbounds for i = i0+1:i1
         val = by[v[i]]


### PR DESCRIPTION
by converting them to `StringArray{WeakRefString{UInt8}}`

Are there any compile time implications of this? @JeffBezanson 