### PR TITLE
Eliminate duplicate and invalid exports

### DIFF
--- a/src/join.jl
+++ b/src/join.jl
@@ -623,7 +623,7 @@ for (fn, how) in [:naturaljoin =>     (:inner, false, concat_tup),
         $fn($f, left, right; kwargs...)
     end
 end
-export naturaljoin, innerjoin, leftjoin, asofjoin, leftjoin!, groupjoin
+export innerjoin, asofjoin, groupjoin
 
 ## Joins
 


### PR DESCRIPTION
naturaljoin and leftjoin are both defined and exported in the preceding for loop.
leftjoin! is not defined at all in this package.

