### PR TITLE
Round of doc cleanup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ environment:
   - julia_version: nightly
 
 platform:
-  - x86 # 32-bit
   - x64 # 64-bit
 
 matrix:

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -8,7 +8,7 @@ import Base:
     permutedims, sort, sort!, iterate, pairs
 
 export NDSparse, flush!, aggregate!, aggregate_vec, where, convertdim, columns, column, rows,
-    itable, update!, aggregate, reducedim_vec, dimlabels, collect_columns
+    update!, aggregate, reducedim_vec, dimlabels, collect_columns
 
 const Tup = Union{Tuple,NamedTuple}
 const DimName = Union{Int,Symbol}

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -13,22 +13,12 @@ Collect an iterable as a `Columns` object if it iterates `Tuples` or `NamedTuple
 
 ## Examples
 
-```jldoctest collect
-julia> s = [(1,2), (3,4)];
+```
+s = [(1,2), (3,4)]
+collect_columns(s)
 
-julia> collect_columns(s)
-2-element Columns{Tuple{Int64,Int64}}:
- (1, 2)
- (3, 4)
-
- julia> s = Iterators.filter(isodd, 1:8);
-
- julia> collect_columns(s)
- 4-element Array{Int64,1}:
-  1
-  3
-  5
-  7
+s2 = Iterators.filter(isodd, 1:8)
+collect_columns(s2)
 ```
 """
 collect_columns(itr) = collect_columns(itr, Base.IteratorSize(itr))

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -172,43 +172,20 @@ function _flatten!(others, vecvec, out_others, out_vecvec)
 end
 
 """
-`flatten(t::Table, col=length(columns(t)))`
+    flatten(t::Table, col=length(columns(t)))
 
 Flatten `col` column which may contain a vector of vectors while repeating the other fields.
 If column argument is not provided, default to last column.
 
-## Examples:
+# Examples:
 
-```jldoctest
-julia> x = table([1,2], [[3,4], [5,6]], names=[:x, :y])
-Table with 2 rows, 2 columns:
-x  y
-─────────
-1  [3, 4]
-2  [5, 6]
+    x = table([1,2], [[3,4], [5,6]], names=[:x, :y])
+    flatten(x, 2)
 
-julia> flatten(x, 2)
-Table with 4 rows, 2 columns:
-x  y
-────
-1  3
-1  4
-2  5
-2  6
-
-julia> x = table([1,2], [table([3,4],[5,6], names=[:a,:b]),
-                         table([7,8], [9,10], names=[:a,:b])], names=[:x, :y]);
-
-julia> flatten(x, :y)
-Table with 4 rows, 3 columns:
-x  a  b
-────────
-1  3  5
-1  4  6
-2  7  9
-2  8  10
-```
-
+    t1 = table([3,4],[5,6], names=[:a,:b])
+    t2 = table([7,8], [9,10], names=[:a,:b])
+    x = table([1,2], [t1, t2], names=[:x, :y]);
+    flatten(x, :y)
 """
 function flatten(t::NextTable, col=length(columns(t)); pkey=nothing)
     vecvec = rows(t, col)

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -91,67 +91,22 @@ function Base.iterate(iter::GroupReduce, i1=1)
 end
 
 """
-`groupreduce(f, t[, by::Selection]; select::Selection)`
+    groupreduce(f, t, by = pkeynames(t); select)
 
-Group rows by `by`, and apply `f` to reduce each group. `f` can be a function, OnlineStat or a struct of these as described in [`reduce`](@ref). Recommended: see documentation for [`reduce`](@ref) first. The result of reducing each group is put in a table keyed by unique `by` values, the names of the output columns are the same as the names of the fields of the reduced tuples.
+Calculate a [`reduce`](@ref) operation `f` over table `t` on groups defined by the values 
+in selection `by`.  The result is put in a table keyed by the unique `by` values.
 
 # Examples
 
-```jldoctest groupreduce
-julia> t=table([1,1,1,2,2,2], [1,1,2,2,1,1], [1,2,3,4,5,6],
-               names=[:x,:y,:z]);
+    t = table([1,1,1,2,2,2], 1:6, names=[:x, :y])
+    groupreduce(+,        t, :x; select = :y)
+    groupreduce((sum=+,), t, :x; select = :y)  # change output column name to :sum
 
-julia> groupreduce(+, t, :x, select=:z)
-Table with 2 rows, 2 columns:
-x  +
-─────
-1  6
-2  15
+    t2 = table([1,1,1,2,2,2], [1,1,2,2,3,3], 1:6, names = [:x, :y, :z])
+    groupreduce(+, t2, (:x, :y), select = :z)
 
-julia> groupreduce(+, t, (:x, :y), select=:z)
-Table with 4 rows, 3 columns:
-x  y  +
-────────
-1  1  3
-1  2  3
-2  1  11
-2  2  4
-
-julia> groupreduce((+, min, max), t, (:x, :y), select=:z)
-Table with 4 rows, 5 columns:
-x  y  +   min  max
-──────────────────
-1  1  3   1    2
-1  2  3   3    3
-2  1  11  5    6
-2  2  4   4    4
-```
-
-If `f` is a single function or a tuple of functions, the output columns will be named the same as the functions themselves. To change the name, pass a named tuple:
-
-```jldoctest groupreduce
-julia> groupreduce(@NT(zsum=+, zmin=min, zmax=max), t, (:x, :y), select=:z)
-Table with 4 rows, 5 columns:
-x  y  zsum  zmin  zmax
-──────────────────────
-1  1  3     1     2
-1  2  3     3     3
-2  1  11    5     6
-2  2  4     4     4
-```
-
-Finally, it's possible to select different inputs for different reducers by using a named tuple of `slector => function` pairs:
-
-```jldoctest groupreduce
-julia> groupreduce(@NT(xsum=:x=>+, negysum=(:y=>-)=>+), t, :x)
-Table with 2 rows, 3 columns:
-x  xsum  negysum
-────────────────
-1  3     -4
-2  6     -4
-
-```
-
+    # different reducers for different columns
+    groupreduce((sumy = :y => +, sumz = :z => +), t2, :x)  
 """
 function groupreduce(f, t::Dataset, by=pkeynames(t);
                      select = t isa AbstractIndexedTable ? Not(by) : valuenames(t),
@@ -230,103 +185,28 @@ collectiontype(::Type{<:NextTable}) = NextTable
 collectiontype(t::Dataset) = collectiontype(typeof(t))
 
 """
-`groupby(f, t[, by::Selection]; select::Selection, flatten)`
+    groupby(f, t, by = pkeynames(t); select, flatten=false)
 
-Group rows by `by`, and apply `f` to each group. `f` can be a function or a tuple of functions. The result of `f` on each group is put in a table keyed by unique `by` values. `flatten` will flatten the result and can be used when `f` returns a vector instead of a single scalar value.
+Apply `f` to the `select`-ed columns (see [`select`](@ref)) in groups defined by the 
+unique values of `by`. 
+
+If `f` returns a vector, split it into multiple columns with `flatten = true`.
 
 # Examples
 
-```jldoctest groupby
-julia> t=table([1,1,1,2,2,2], [1,1,2,2,1,1], [1,2,3,4,5,6],
-               names=[:x,:y,:z]);
+    using Statistics
 
-julia> groupby(mean, t, :x, select=:z)
-Table with 2 rows, 2 columns:
-x  mean
-───────
-1  2.0
-2  5.0
+    t=table([1,1,1,2,2,2], [1,1,2,2,1,1], [1,2,3,4,5,6], names=[:x,:y,:z])
 
-julia> groupby(identity, t, (:x, :y), select=:z)
-Table with 4 rows, 3 columns:
-x  y  identity
-──────────────
-1  1  [1, 2]
-1  2  [3]
-2  1  [5, 6]
-2  2  [4]
+    groupby(mean, t, :x, select=:z)
+    groupby(identity, t, (:x, :y), select=:z)
+    groupby(mean, t, (:x, :y), select=:z)
 
-julia> groupby(mean, t, (:x, :y), select=:z)
-Table with 4 rows, 3 columns:
-x  y  mean
-──────────
-1  1  1.5
-1  2  3.0
-2  1  5.5
-2  2  4.0
-```
+    groupby((mean, std, var), t, :y, select=:z)
+    groupby((q25=z->quantile(z, 0.25), q50=median, q75=z->quantile(z, 0.75)), t, :y, select=:z)
 
-multiple aggregates can be computed by passing a tuple of functions:
-
-```jldoctest groupby
-julia> groupby((mean, std, var), t, :y, select=:z)
-Table with 2 rows, 4 columns:
-y  mean  std       var
-──────────────────────────
-1  3.5   2.38048   5.66667
-2  3.5   0.707107  0.5
-
-julia> groupby(@NT(q25=z->quantile(z, 0.25), q50=median,
-                   q75=z->quantile(z, 0.75)), t, :y, select=:z)
-Table with 2 rows, 4 columns:
-y  q25   q50  q75
-──────────────────
-1  1.75  3.5  5.25
-2  3.25  3.5  3.75
-```
-
-Finally, it's possible to select different inputs for different functions by using a named tuple of `slector => function` pairs:
-
-```jldoctest groupby
-julia> groupby(@NT(xmean=:z=>mean, ystd=(:y=>-)=>std), t, :x)
-Table with 2 rows, 3 columns:
-x  xmean  ystd
-─────────────────
-1  2.0    0.57735
-2  5.0    0.57735
-```
-
-By default, the result of groupby when `f` returns a vector or iterator of values will not be expanded. Pass the `flatten` option as `true` to flatten the grouped column:
-
-```jldoctest
-julia> t = table([1,1,2,2], [3,4,5,6], names=[:x,:y])
-
-julia> groupby((:normy => x->Iterators.repeated(mean(x), length(x)),),
-                t, :x, select=:y, flatten=true)
-Table with 4 rows, 2 columns:
-x  normy
-────────
-1  3.5
-1  3.5
-2  5.5
-2  5.5
-```
-
-The keyword option `usekey = true` allows to use information from the indexing column. `f` will need to accept two
-arguments, the first being the key (as a `Tuple` or `NamedTuple`) the second the data (as `Columns`).
-
-```jldoctest
-julia> t = table([1,1,2,2], [3,4,5,6], names=[:x,:y])
-
-julia> groupby((:x_plus_mean_y => (key, d) -> key.x + mean(d),),
-                              t, :x, select=:y, usekey = true)
-Table with 2 rows, 2 columns:
-x  x_plus_mean_y
-────────────────
-1  4.5
-2  7.5
-```
-
+    # apply different aggregation functions to different columns
+    groupby((ymean = :y => mean, zmean = :z => mean), t, :x)
 """
 function groupby end
 
@@ -390,52 +270,22 @@ init_func(ac::ApplyColwise, t::Columns) =
 init_func(ac::ApplyColwise, t::AbstractVector) = ac.functions
 
 """
-`summarize(f, t, by = pkeynames(t); select = excludecols(t, by), stack = false, variable = :variable)`
+    summarize(f, t, by = pkeynames(t); select = Not(by), stack = false, variable = :variable)
 
 Apply summary functions column-wise to a table. Return a `NamedTuple` in the non-grouped case
-and a table in the grouped case. Use `stack=true` to stack results of the same summary function for different columns.
+and a table in the grouped case. Use `stack=true` to stack results of the same summary function 
+for different columns.
 
 # Examples
 
-```jldoctest colwise
-julia> t = table([1, 2, 3], [1, 1, 1], names = [:x, :y]);
+    using Statistics
 
-julia> summarize((mean, std), t)
-(x_mean = 2.0, y_mean = 1.0, x_std = 1.0, y_std = 0.0)
+    t = table([1, 2, 3], [1, 1, 1], names = [:x, :y])
 
-julia> s = table(["a","a","b","b"], [1,3,5,7], [2,2,2,2], names = [:x, :y, :z], pkey = :x);
-
-julia> summarize(mean, s)
-Table with 2 rows, 3 columns:
-x    y    z
-─────────────
-"a"  2.0  2.0
-"b"  6.0  2.0
-
-julia> summarize(mean, s, stack = true)
-Table with 4 rows, 3 columns:
-x    variable  mean
-───────────────────
-"a"  :y        2.0
-"a"  :z        2.0
-"b"  :y        6.0
-"b"  :z        2.0
-```
-
-Use a `NamedTuple` to have different names for the summary functions:
-
-```jldoctest colwise
-julia> summarize(@NT(m = mean, s = std), t)
-(x_m = 2.0, y_m = 1.0, x_s = 1.0, y_s = 0.0)
-```
-
-Use `select` to only summarize some columns:
-
-```jldoctest colwise
-julia> summarize(@NT(m = mean, s = std), t, select = :x)
-(m = 2.0, s = 1.0)
-```
-
+    summarize((mean, std), t)
+    summarize((m = mean, s = std), t)
+    summarize(mean, t; stack=true)
+    summarize((mean, std), t; select = :y)
 """
 function summarize(f, t, by = pkeynames(t); select = t isa AbstractIndexedTable ? excludecols(t, by) : valuenames(t), stack = false, variable = :variable)
     flatten = stack && !(select isa Union{Int, Symbol})
@@ -479,40 +329,16 @@ convertdim(x::NDSparse, d::Int, xlat, agg) = convertdim(x, d, xlat, agg=agg)
 sum(x::NDSparse) = sum(x.data)
 
 """
-`reduce(f, x::NDSparse, dims)`
+    reduce(f, x::NDSparse; dims)
 
-Drop `dims` dimension(s) and aggregate with `f`.
+Drop the `dims` dimension(s) and aggregate values with `f`.
 
-```jldoctest
-julia> x = ndsparse(@NT(x=[1,1,1,2,2,2],
-                        y=[1,2,2,1,2,2],
-                        z=[1,1,2,1,1,2]), [1,2,3,4,5,6])
-3-d NDSparse with 6 values (Int64):
-x  y  z │
-────────┼──
-1  1  1 │ 1
-1  2  1 │ 2
-1  2  2 │ 3
-2  1  1 │ 4
-2  2  1 │ 5
-2  2  2 │ 6
-
-julia> reduce(+, x, 1)
-2-d NDSparse with 3 values (Int64):
-y  z │
-─────┼──
-1  1 │ 5
-2  1 │ 7
-2  2 │ 9
-
-julia> reduce(+, x, (1,3))
-1-d NDSparse with 2 values (Int64):
-y │
-──┼───
-1 │ 5
-2 │ 16
-
-```
+    x = ndsparse((x=[1,1,1,2,2,2],
+                  y=[1,2,2,1,2,2],
+                  z=[1,1,2,1,1,2]), [1,2,3,4,5,6])
+                  
+    reduce(+, x; dims=1)
+    reduce(+, x; dims=(1,3))
 """
 function Base.reduce(f, x::NDSparse; kws...)
     if haskey(kws, :dims)

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -1,30 +1,20 @@
 export stack, unstack
 
 """
-`stack(t, by = pkeynames(t); select = excludecols(t, by), variable = :variable, value = :value)`
+    stack(t, by = pkeynames(t); select = Not(by), variable = :variable, value = :value)`
 
 Reshape a table from the wide to the long format. Columns in `by` are kept as indexing columns.
-Columns in `select` are stacked. In addition to the id columns, two additional columns labeled `variable` and `value`
-are added, containg the column identifier and the stacked columns.
+Columns in `select` are stacked. In addition to the id columns, two additional columns labeled 
+`variable` and `value` are added, containing the column identifier and the stacked columns.
+See also [`unstack`](@ref).
 
-## Examples
+# Examples
 
-```jldoctest stack
-julia> t = table(1:4, [1, 4, 9, 16], [1, 8, 27, 64], names = [:x, :xsquare, :xcube], pkey = :x);
+    t = table(1:4, names = [:x], pkey=:x)
+    t = pushcol(t, :xsquare, :x => x -> x^2)
+    t = pushcol(t, :xcube  , :x => x -> x^3)
 
-julia> stack(t)
-Table with 8 rows, 3 columns:
-x  variable  value
-──────────────────
-1  :xsquare  1
-1  :xcube    1
-2  :xsquare  4
-2  :xcube    8
-3  :xsquare  9
-3  :xcube    27
-4  :xsquare  16
-4  :xcube    64
-```
+    stack(t)
 """
 function stack(t::D, by = pkeynames(t); select = isa(t, NDSparse) ? valuenames(t) : excludecols(t, by),
     variable = :variable, value = :value) where {D<:Dataset}
@@ -54,39 +44,19 @@ function unstack(::Type{D}, ::Type{T}, key, val, cols::AbstractVector{S}) where 
 end
 
 """
-`unstack(t, by = pkeynames(t); variable = :variable, value = :value)`
+    unstack(t, by = pkeynames(t); variable = :variable, value = :value)
 
 Reshape a table from the long to the wide format. Columns in `by` are kept as indexing columns.
 Keyword arguments `variable` and `value` denote which column contains the column identifier and
-which the corresponding values.
+which the corresponding values.  See also [`stack`](@ref).
 
-## Examples
+# Examples
 
-```jldoctest unstack
-julia> t = table(1:4, [1, 4, 9, 16], [1, 8, 27, 64], names = [:x, :xsquare, :xcube], pkey = :x);
+    t = table(1:4, [1, 4, 9, 16], [1, 8, 27, 64], names = [:x, :xsquare, :xcube], pkey = :x);
 
-julia> long = stack(t)
-Table with 8 rows, 3 columns:
-x  variable  value
-──────────────────
-1  :xsquare  1
-1  :xcube    1
-2  :xsquare  4
-2  :xcube    8
-3  :xsquare  9
-3  :xcube    27
-4  :xsquare  16
-4  :xcube    64
+    long = stack(t)
 
-julia> unstack(long)
-Table with 4 rows, 3 columns:
-x  xsquare  xcube
-─────────────────
-1  1        1
-2  4        8
-3  9        27
-4  16       64
-```
+    unstack(long)
 """
 function unstack(t::D, by = pkeynames(t); variable = :variable, value = :value) where {D<:Dataset}
     tgrp = groupby((value => identity,), t, by, select = (variable, value))

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -54,38 +54,19 @@ function selectvalues(x::NDSparse, which; presorted=true, copy=false, kwargs...)
 end
 
 """
-`reindex(t::Table, by[, select])`
+    reindex(t::NextTable, by)
+    reindex(t::NextTable, by, select)
 
-Reindex `t` by columns selected in `by`.
-Keeps columns selected by `select` as non-indexed columns.
-By default all columns not mentioned in `by` are kept.
+Reindex table `t` with new primary key `by`, optionally keeping a subset of columns via
+`select`.  For [`NDSparse`](@ref), use [`selectkeys`](@ref).
 
-Use [`selectkeys`](@ref) to reindex and NDSparse object.
+# Example
 
-```jldoctest reindex
-julia> t = table([2,1],[1,3],[4,5], names=[:x,:y,:z], pkey=(1,2))
+    t = table([2,1],[1,3],[4,5], names=[:x,:y,:z], pkey=(1,2))
 
-julia> reindex(t, (:y, :z))
-Table with 2 rows, 3 columns:
-y  z  x
-───────
-1  4  2
-3  5  1
+    t2 = reindex(t, (:y, :z))
 
-julia> pkeynames(t)
-(:y, :z)
-
-julia> reindex(t, (:w=>[4,5], :z))
-Table with 2 rows, 4 columns:
-w  z  x  y
-──────────
-4  5  1  3
-5  4  2  1
-
-julia> pkeynames(t)
-(:w, :z)
-
-```
+    pkeynames(t2)
 """
 function reindex end
 
@@ -119,53 +100,18 @@ canonname(t, x::Symbol) = x
 canonname(t, x::Int) = colnames(t)[colindex(t, x)]
 
 """
-`map(f, t::Table; select)`
+    map(f, t::NextTable; select)
 
-Apply `f` to every row in `t`. `select` selects fields
-passed to `f`.
-
-Returns a new table if `f` returns a tuple or named tuple.
-If not, returns a vector.
+Apply `f` to every item in `t` selected by `select` (see also the [`select`](@ref) function).  
+Returns a new table if `f` returns a tuple or named tuple.  If not, returns a vector.
 
 # Examples
 
-```jldoctest map
-julia> t = table([0.01, 0.05], [1,2], [3,4], names=[:t, :x, :y])
-Table with 2 rows, 3 columns:
-t     x  y
-──────────
-0.01  1  3
-0.05  2  4
+    t = table([1,2], [3,4], names=[:x, :y])
 
-julia> manh = map(row->row.x + row.y, t)
-2-element Array{Int64,1}:
- 4
- 6
+    polar = map(p -> (r = hypot(p.x, p.y), θ = atan(p.y, p.x)), t)
 
-julia> polar = map(p->@NT(r=hypot(p.x + p.y), θ=atan2(p.y, p.x)), t)
-Table with 2 rows, 2 columns:
-r    θ
-────────────
-4.0  1.24905
-6.0  1.10715
-
-```
-
-`select` argument selects a subset of columns while iterating.
-
-```jldoctest map
-
-julia> vx = map(row->row.x/row.t, t, select=(:t,:x)) # row only cotains t and x
-2-element Array{Float64,1}:
- 100.0
-  40.0
-
-julia> map(sin, polar, select=:θ)
-2-element Array{Float64,1}:
- 0.948683
- 0.894427
-
-```
+    back2t = map(p -> (x = p.r * cos(p.θ), y = p.r * sin(p.θ)), polar)
 """
 function map(f, t::AbstractIndexedTable; select=nothing) end
 
@@ -207,55 +153,19 @@ function _nonna(t::Union{Columns, NextTable}, by=(colnames(t)...,))
 end
 
 """
-`dropna(t[, select])`
+    dropna(t)
+    dropna(t, select)
 
-Drop rows which contain NA values.
+Drop rows of table `t` which contain NA (`DataValues.DataValue`) values, optionally only 
+using the columns in `select`.  
 
-```jldoctest dropna
-julia> t = table([0.1, 0.5, NA,0.7], [2,NA,4,5], [NA,6,NA,7],
-                  names=[:t,:x,:y])
-Table with 4 rows, 3 columns:
-t    x    y
-─────────────
-0.1  2    #NA
-0.5  #NA  6
-#NA  4    #NA
-0.7  5    7
+Column types will be converted to non-NA types.  E.g. `Array{DataValue{Int}}` to `Array{Int}`.
 
-julia> dropna(t)
-Table with 1 rows, 3 columns:
-t    x  y
-─────────
-0.7  5  7
-```
-Optionally `select` can be speicified to limit columns to look for NAs in.
+# Example
 
-```jldoctest dropna
-
-julia> dropna(t, :y)
-Table with 2 rows, 3 columns:
-t    x    y
-───────────
-0.5  #NA  6
-0.7  5    7
-
-julia> t1 = dropna(t, (:t, :x))
-Table with 2 rows, 3 columns:
-t    x  y
-───────────
-0.1  2  #NA
-0.7  5  7
-```
-
-Any columns whose NA rows have been dropped will be converted
-to non-na array type. In our last example, columns `t` and `x`
-got converted from `Array{DataValue{Int}}` to `Array{Int}`.
-Similarly if the vectors are of type `DataValueArray{T}`
-(default for `loadtable`) they will be converted to `Array{T}`.
-```julia
-julia> typeof(column(dropna(t,:x), :x))
-Array{Int64,1}
-```
+    t = table([0.1,0.5,NA,0.7], [2,NA,4,5], [NA,6,NA,7], names=[:t,:x,:y])
+    dropna(t)
+    dropna(t, (:t, :x))
 """
 function dropna(t::Dataset, by=(colnames(t)...,))
     subtable(_nonna(t, by)...,)
@@ -264,100 +174,24 @@ end
 filt_by_col!(f, col, indxs) = filter!(i->f(col[i]), indxs)
 
 """
-`filter(pred, t::Union{NextTable, NDSparse}; select)`
+    filter(f, t::Union{NextTable, NDSparse}; select)
 
-Filter rows in `t` according to `pred`. `select` choses the fields that act as input to `pred`.
+Iterate over `t` and Return the rows for which `f(row)` returns true.  `select` determines 
+the rows that are given as arguments to `f` (see [`select`](@ref)).
 
-`pred` can be:
+`f` can also be a tuple of `column => function` pairs.  Returned rows will be those for
+which all conditions are true.
 
-- A function - selected structs or values are passed to this function
-- A tuple of `column => function` pairs: applies to each named column the corresponding function, keeps only rows where all such conditions are satisfied.
 
-By default, `filter` iterates a table a row at a time:
-```jldoctest filter
-julia> t = table(["a","b","c"], [0.01, 0.05, 0.07], [2,1,0],
-                 names=[:n, :t, :x])
-Table with 3 rows, 3 columns:
-n    t     x
-────────────
-"a"  0.01  2
-"b"  0.05  1
-"c"  0.07  0
+# Example
 
-julia> filter(p->p.x/p.t < 100, t) # whole row
-Table with 2 rows, 3 columns:
-n    t     x
-────────────
-"b"  0.05  1
-"c"  0.07  0
+    # filter iterates over ROWS of a NextTable
+    t = table(rand(100), rand(100), rand(100), names = [:x, :y, :z])
+    filter(r -> r.x + r.y + r.z < 1, t)
 
-```
-
-By default, `filter` iterates by values of an `NDSparse`:
-
-```jldoctest filter
-julia> x = ndsparse(@NT(n=["a","b","c"], t=[0.01, 0.05, 0.07]), [2,1,0])
-2-d NDSparse with 3 values (Int64):
-n    t    │
-──────────┼──
-"a"  0.01 │ 2
-"b"  0.05 │ 1
-"c"  0.07 │ 0
-
-julia> filter(y->y<2, x)
-2-d NDSparse with 2 values (Int64):
-n    t    │
-──────────┼──
-"b"  0.05 │ 1
-"c"  0.07 │ 0
-```
-
-If select is specified. (See [Selection convention](@ref select)) then, the selected values will be iterated instead.
-
-```jldoctest filter
-julia> filter(iseven, t, select=:x)
-Table with 2 rows, 3 columns:
-n    t     x
-────────────
-"a"  0.01  2
-"c"  0.07  0
-
-julia> filter(p->p.x/p.t < 100, t, select=(:x,:t))
-Table with 2 rows, 3 columns:
-n    t     x
-────────────
-"b"  0.05  1
-"c"  0.07  0
-```
-
-`select` works similarly for `NDSparse`:
-```jldoctest filter
-julia> filter(p->p[2]/p[1] < 100, x, select=(:t, 3))
-2-d NDSparse with 2 values (Int64):
-n    t    │
-──────────┼──
-"b"  0.05 │ 1
-"c"  0.07 │ 0
-```
-Here 3 represents the third column, which is the values, `p` is a tuple of `t` field and the value.
-
-Filtering by many single columns can be done by passing a tuple of `column_name => function` pairs.
-
-```jldoctest filter
-julia> filter((:x=>iseven, :t=>a->a>0.01), t)
-Table with 1 rows, 3 columns:
-n    t     x
-────────────
-"c"  0.07  0
-
-julia> filter((3=>iseven, :t=>a->a>0.01), x) # NDSparse
-2-d NDSparse with 1 values (Int64):
-n    t    │
-──────────┼──
-"c"  0.07 │ 0
-
-```
-
+    # filter iterates over VALUES of an NDSparse
+    x = ndsparse(1:100, randn(100))
+    filter(val -> val > 0, x)
 """
 function Base.filter(fn, t::Dataset; select=valuenames(t))
     x = rows(t, select)

--- a/src/table.jl
+++ b/src/table.jl
@@ -17,6 +17,10 @@ end
 
 abstract type AbstractIndexedTable end
 
+"""
+A tabular data structure that extends [`Columns`](@ref).  Create a `NextTable` with the 
+[`table`](@ref) function.
+"""
 struct NextTable{C<:Columns} <: AbstractIndexedTable
     # `Columns` object which iterates to give an array of rows
     columns::C
@@ -31,151 +35,43 @@ struct NextTable{C<:Columns} <: AbstractIndexedTable
 end
 
 """
-`table(cols::AbstractVector...; names, <options>)`
+    table(cols; kw...)
 
-Create a table with columns given by `cols`.
-```jldoctest table
-julia> a = table([1,2,3], [4,5,6])
-Table with 3 rows, 2 columns:
-1  2
-────
-1  4
-2  5
-3  6
-```
+Create a table from a (named) tuple of AbstractVectors.
 
-`names` specify names for columns. If specified, the table will be an iterator of named tuples.
+    table(cols::AbstractVector...; names::Vector{Symbol}, kw...)
 
-```jldoctest table
-julia> b = table([1,2,3], [4,5,6], names=[:x, :y])
-Table with 3 rows, 2 columns:
-x  y
-────
-1  4
-2  5
-3  6
+Create a table from the provided `cols`, optionally with `names`.
 
-```
+    table(cols::Columns; kw...)
 
-`table(cols::Union{Tuple, NamedTuple}; <options>)`
+Construct a table from a vector of tuples. See [`rows`](@ref) and [`Columns`](@ref).
 
-Convert a struct of columns to a table of structs.
-
-```jldoctest table
-julia> table(([1,2,3], [4,5,6])) == a
-true
-
-julia> table(@NT(x=[1,2,3], y=[4,5,6])) == b
-true
-```
-
-`table(cols::Columns; <options>)`
-
-Construct a table from a vector of tuples. See [`rows`](@ref).
-
-```jldoctest table
-julia> table(Columns([1,2,3], [4,5,6])) == a
-true
-
-julia> table(Columns(x=[1,2,3], y=[4,5,6])) == b
-true
-```
-
-`table(t::Union{Table, NDSparse}; <options>)`
+    table(t::Union{NextTable, NDSparse}; kw...)
 
 Copy a Table or NDSparse to create a new table. The same primary keys as the input are used.
 
-```jldoctest table
-julia> b == table(b)
-true
-```
-
-`table(iter; <options>)`
-
-Construct a table from an iterable table.
+    table(iter; kw...)
 
 
-# Options:
+# Keyword Argument Options:
 
-- `pkey`: select columns to act as the primary key. By default, no columns are used as primary key.
-- `presorted`: is the data pre-sorted by primary key columns? If so, skip sorting. `false` by default. Irrelevant if `chunks` is specified.
-- `copy`: creates a copy of the input vectors if `true`. `true` by default. Irrelavant if `chunks` is specified.
-- `chunks`: distribute the table into `chunks` (Integer) chunks (a safe bet is nworkers()). Table is not distributed by default. See [Distributed](@distributed) docs.
+- `pkey`: select columns to sort by and be the primary key.
+- `presorted = false`: is the data pre-sorted by primary key columns? 
+- `copy = true`: creates a copy of the input vectors if `true`. Irrelevant if `chunks` is specified.
+- `chunks::Integer`: distribute the table.  Options are:
+    - `Int` -- (number of chunks) a safe bet is `nworkers()` after `using Distributed`.
+    - `Vector{Int}` -- Number of elements in each of the `length(chunks)` chunks.
 
 # Examples:
 
-Specifying `pkey` will cause the table to be sorted by the columns named in pkey:
+    table(rand(10), rand(10), names = [:x, :y], pkey = :x)
 
-```jldoctest table
-julia> b = table([2,3,1], [4,5,6], names=[:x, :y], pkey=:x)
-Table with 3 rows, 2 columns:
-x  y
-────
-1  6
-2  4
-3  5
+    table(rand(Bool, 20), rand(20), rand(20), pkey = [1,2])
 
-julia> b = table([2,1,2,1],[2,3,1,3],[4,5,6,7],
-                 names=[:x, :y, :z], pkey=(:x,:y))
-Table with 4 rows, 3 columns:
-x  y  z
-───────
-1  3  5
-1  3  7
-2  1  6
-2  2  4
-```
-Note that the keys do not have to be unique.
+    table((x = 1:10, y = randn(10)))
 
-`chunks` option creates a distributed table.
-
-`chunks` can be:
-
-1. An integer -- number of chunks to create
-2. An vector of `k` integers -- number of elements in each of the `k` chunks.
-3. The distribution of another array. i.e. `vec.subdomains` where `vec` is a distributed array.
-
-```jldoctest table
-julia> t = table([2,3,1,4], [4,5,6,7],
-                  names=[:x, :y], pkey=:x, chunks=2)
-Distributed Table with 4 rows in 2 chunks:
-x  y
-────
-1  6
-2  4
-3  5
-4  7
-```
-
-A distributed table will be constructed if one of the arrays passed into `table` constructor is a distributed
-array. A distributed Array can be constructed using `distribute`:
-
-```jldoctest table
-
-julia> x = distribute([1,2,3,4], 2);
-
-julia> t = table(x, [5,6,7,8], names=[:x,:y])
-Distributed Table with 4 rows in 2 chunks:
-x  y
-────
-1  5
-2  6
-3  7
-4  8
-
-julia> table(columns(t)..., [9,10,11,12],
-             names=[:x,:y,:z])
-Distributed Table with 4 rows in 2 chunks:
-x  y  z
-────────
-1  5  9
-2  6  10
-3  7  11
-4  8  12
-
-```
-
-Distribution is done to match the first distributed column from left to right. Specify `chunks` to override this.
+    table([(1,2), (3,4)])
 """
 function table end
 
@@ -373,32 +269,20 @@ permcache(t::NextTable) = vcat(primaryperm(t), t.perms)
 cacheperm!(t::NextTable, p) = push!(t.perms, p)
 
 """
-`pkeynames(t::Table)`
+    pkeynames(t::Table)
 
 Names of the primary key columns in `t`.
 
-# Example
+# Examples
 
-```jldoctest pkeynames
+    t = table([1,2], [3,4]);
+    pkeynames(t)
 
-julia> t = table([1,2], [3,4]);
+    t = table([1,2], [3,4], pkey=1);
+    pkeynames(t)
 
-julia> pkeynames(t)
-()
-
-julia> t = table([1,2], [3,4], pkey=1);
-
-julia> pkeynames(t)
-(1,)
-
-julia> t = table([2,1],[1,3],[4,5], names=[:x,:y,:z], pkey=(1,2));
-
-julia> pkeys(t)
-2-element IndexedTables.Columns{NamedTuples._NT_x_y{Int64,Int64},NamedTuples._NT_x_y{Array{Int64,1},Array{Int64,1}}}:
- (x = 1, y = 3)
- (x = 2, y = 1)
-
-```
+    t = table([2,1],[1,3],[4,5], names=[:x,:y,:z], pkey=(1,2));
+    pkeynames(t)
 """
 function pkeynames(t::AbstractIndexedTable)
     if eltype(t) <: NamedTuple
@@ -412,7 +296,7 @@ end
 valuenames(t::AbstractIndexedTable) = (colnames(t)...,)
 
 """
-    pkeys(itr::Table)
+    pkeys(itr::NextTable)
 
 Primary keys of the table. If Table doesn't have any designated
 primary key columns (constructed without `pkey` argument) then
@@ -420,33 +304,11 @@ a default key of tuples `(1,):(n,)` is generated.
 
 # Example
 
-```jldoctest pkeys
+    a = table(["a","b"], [3,4]) # no pkey
+    pkeys(a)
 
-julia> a = table(["a","b"], [3,4]) # no pkey
-Table with 2 rows, 2 columns:
-1    2
-──────
-"a"  3
-"b"  4
-
-julia> pkeys(a)
-2-element Columns{Tuple{Int64}}:
- (1,)
- (2,)
-
-julia> a = table(["a","b"], [3,4], pkey=1)
-Table with 2 rows, 2 columns:
-1    2
-──────
-"a"  3
-"b"  4
-
-julia> pkeys(a)
-2-element Columns{Tuple{String}}:
- ("a",)
- ("b",)
-```
-
+    a = table(["a","b"], [3,4], pkey=1)
+    pkeys(a)
 """
 function pkeys(t::NextTable)
     if isempty(t.pkey)
@@ -459,54 +321,30 @@ end
 Base.values(t::NextTable) = rows(t)
 
 """
-`sort(t[, by::Selection]; select::Selection, kwargs...)`
+    sort(t    ; select, kw...)
+    sort(t, by; select, kw...)
 
-Sort rows by `by`. All of `Base.sort` keywords can be used.
+Sort rows by `by`. All of `Base.sort` keyword arguments can be used.
 
 # Examples
 
-```jldoctest sort
-julia> t=table([1,1,1,2,2,2], [1,1,2,2,1,1], [1,2,3,4,5,6],
-names=[:x,:y,:z]);
-
-julia> sort(t, :z; select = (:y, :z), rev = true)
-Table with 6 rows, 2 columns:
-y  z
-────
-1  6
-1  5
-2  4
-2  3
-1  2
-1  1
-```
+    t=table([1,1,1,2,2,2], [1,1,2,2,1,1], [1,2,3,4,5,6],
+    sort(t, :z; select = (:y, :z), rev = true)
 """
 sort(t::NextTable, by...; select = valuenames(t), kwargs...) =
     table(rows(t, select)[sortperm(rows(t, by...); kwargs...)], copy = false)
 
 """
-`sort!(t[, by::Selection]; kwargs...)`
+    sort!(t    ; kw...)
+    sort!(t, by; kw...)
 
-Sort rows by `by` in place. All of `Base.sort` keywords can be used.
+Sort rows of `t` by `by` in place. All of `Base.sort` keyword arguments can be used.
 
 # Examples
 
-```jldoctest sort!
-julia> t=table([1,1,1,2,2,2], [1,1,2,2,1,1], [1,2,3,4,5,6],
-names=[:x,:y,:z]);
-
-julia> sort!(t, :z, rev = true);
-
-julia> t
-Table with 6 rows, 3 columns:
-x  y  z
-───────
-2  1  6
-2  1  5
-2  2  4
-1  2  3
-1  1  2
-1  1  1
+    t = table([1,1,1,2,2,2], [1,1,2,2,1,1], [1,2,3,4,5,6], names=[:x,:y,:z]);
+    sort!(t, :z, rev = true)
+    t
 """
 function sort!(t::NextTable, by...; kwargs...)
     isempty(t.pkey) || error("Tables with primary keys can't be sorted in place")
@@ -520,27 +358,16 @@ end
 Names of all columns in `itr` except `cols`. `itr` can be any of
 `Table`, `NDSparse`, `Columns`, or `AbstractVector`
 
-```jldoctest excludecols
-julia> t = table([2,1],[1,3],[4,5], names=[:x,:y,:z], pkey=(1,2))
-Table with 2 rows, 3 columns:
-x  y  z
-───────
-1  3  5
-2  1  4
+# Examples
 
-julia> excludecols(t, (:x,))
-(:y, :z)
+    using IndexedTables: excludecols
 
-julia> excludecols(t, (2,))
-(:x, :z)
+    t = table([2,1],[1,3],[4,5], names=[:x,:y,:z], pkey=(1,2))
 
-julia> excludecols(t, pkeynames(t))
-(:z,)
-
-julia> excludecols([1,2,3], (1,))
-()
-
-```
+    excludecols(t, (:x,))
+    excludecols(t, (2,))
+    excludecols(t, pkeynames(t))
+    excludecols([1,2,3], (1,))
 """
 function excludecols(t, cols)
     if cols isa SpecialSelector

--- a/src/table.jl
+++ b/src/table.jl
@@ -17,9 +17,6 @@ end
 
 abstract type AbstractIndexedTable end
 
-"""
-A table.
-"""
 struct NextTable{C<:Columns} <: AbstractIndexedTable
     # `Columns` object which iterates to give an array of rows
     columns::C
@@ -570,15 +567,7 @@ Construct a table with `pkeys` as primary keys and `vals` as corresponding non-i
 keyword arguments will be forwarded to [`table`](@ref) constructor.
 
 # Example
-
-```jldoctest
-julia> convert(NextTable, Columns(x=[1,2],y=[3,4]), Columns(z=[1,2]), presorted=true)
-Table with 2 rows, 3 columns:
-x  y  z
-───────
-1  3  1
-2  4  2
-```
+    convert(NextTable, Columns(x=[1,2],y=[3,4]), Columns(z=[1,2]), presorted=true)
 """
 function convert(::Type{NextTable}, key, val; kwargs...)
     cs = concat_cols(key, val)


### PR DESCRIPTION
This is the first part of cleaning up the docs in IndexedTables and JuliaDB.  I'm doing this for a few reasons:

# Reasons

1.  JuliaDB docs have not been successfully building for some time.
1.  Many of the doctests fail for silly reasons (IndexedTables now uses the NamedTuples in Base, so tables print slightly different)
1. IndexedTables documents a lot of features in JuliaDB that aren't available in IndexedTables alone.
1. Much of the Documenter `@ref` syntax references pages in the online JuliaDB docs.
1. At the REPL, I want short-form documentation, leaving longer examples for the online documentation.

# Changes

1. Shorter docstrings
    - The docstrings are now a bit shorter and more appropriate for REPL usage.  Longer explanations of nuanced behavior/edge cases will go into the online docs for JuliaDB.
1. Easier-to-read examples
    - I've tried to make simpler examples that take less energy to understand.
1. Remove Documenter style `@ref` syntax to online help pages.  These don't make sense in the REPL and makes it more burdensome to ensure links in the docs are correct.
1. Remove all doctests.
    - Rather than fix a lot of small things that aren't bugs, I've wiped out doctests (failing and passing alike).  Important cases can be added back in at a later time, but I decided it wasn't worth the manual intervention to get them passing again.  
1. Various code cleanup here and there.

# Example

Here's a more drastic example of the changes I'm making:

Original: https://github.com/JuliaComputing/IndexedTables.jl/blob/ecb8a23e314ce9a3b97b6a84f0443c0db70b6329/src/join.jl#L246-L392

New:
```
"""
    join(left, right; kw...)
    join(f, left, right; kw...)

Join tables `left` and `right`.

If a function `f(leftrow, rightrow)` is provided, the returned table will have a single 
output column.  See the Examples below.

If the same key occurs multiple times in either table, each `left` row will get matched 
with each `right` row, resulting in `n_occurrences_left * n_occurrences_right` output rows.

# Options (keyword arguments)

- `how = :inner` -- join method to use. Described below.
- `lkey = pkeys(left)` -- fields from `left` to match on (see [`pkeys`](@ref))
- `rkey = pkeys(right)` -- fields from `right` to match on
- `lselect = Not(lkey)` -- output columns from `left` (see [`Not`](@ref))
- `rselect = Not(rkey)` -- output columns from `right`

## Join methods (`how = :inner`)

- `:inner` -- rows with matching keys in both tables
- `:left` -- all rows from `left`, plus matched rows from `right` (missing values can occur)
- `:outer` -- all rows from both tables (missing values can occur)
- `:anti` -- rows in `left` WITHOUT matching keys in `right`

# Examples

    a = table((x = 1:10,   y = rand(10)), pkey = :x)
    b = table((x = 1:2:20, z = rand(10)), pkey = :x)

    join(a, b; how = :inner)
    join(a, b; how = :left)
    join(a, b; how = :outer)
    join(a, b; how = :anti)

    join((l, r) -> l.y + r.z, a, b)
"""
```

