### PR TITLE
Tables Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,28 @@ be used on its own for efficient in-memory data processing and analytics.
 
 ## Data Structures 
 
-- **The two table types in IndexedTables differ in how data is accessed.**
-- **There is no performance difference between table types for operations such as selecting, filtering, and map/reduce.**
+IndexedTables offers two data structures: `IndexedTable` and `NDSparse`.
+
+- **Both types store data _in columns_**.
+- **`IndexedTable` and `NDSparse` differ mainly in how data is accessed.**
+- **Both types have equal performance fr Table operations (`select`, `filter`, etc.).** 
+
+
+## Quickstart
+
+```
+using Pkg
+Pkg.add("IndexedTables")
+using IndexedTables
+
+t = table((x = 1:100, y = randn(100)))
+
+select(t, :x)
+
+filter(row -> row.y > 0, t)
+```
+
+## `IndexedTable` vs. `NDSparse`
 
 First let's create some data to work with.
 
@@ -22,18 +42,18 @@ city = vcat(fill("New York", 3), fill("Boston", 3))
 
 dates = repeat(Date(2016,7,6):Day(1):Date(2016,7,8), 2)
 
-values = [91, 89, 91, 95, 83, 76]
+vals = [91, 89, 91, 95, 83, 76]
 ```
 
-### Table
+### IndexedTable
 
-- Data is accessed as a Vector of NamedTuples.  
-- Sorted by primary key(s), `pkey`.
+- (Optionally) Sorted by primary key(s), `pkey`.
+- Data is accessed as a Vector of NamedTuples.
 
 ```julia
 using IndexedTables
 
-julia> t1 = table((city = city, dates = dates, values = values); pkey = [:city, :dates])
+julia> t1 = table((city = city, dates = dates, values = vals); pkey = [:city, :dates])
 Table with 6 rows, 3 columns:
 city        dates       values
 ──────────────────────────────
@@ -46,18 +66,15 @@ city        dates       values
 
 julia> t1[1]
 (city = "Boston", dates = 2016-07-06, values = 95)
-
-julia> first(t1)
-(city = "Boston", dates = 2016-07-06, values = 95)
 ```
 
 ### NDSparse
 
-- Data is accessed as an N-dimensional sparse array with arbitrary indexes.
 - Sorted by index variables (first argument).
+- Data is accessed as an N-dimensional sparse array with arbitrary indexes.
 
 ```julia
-julia> t2 = ndsparse(@NT(city=city, dates=dates), @NT(value=values))
+julia> t2 = ndsparse((city=city, dates=dates), (value=vals,))
 2-d NDSparse with 6 values (1 field named tuples):
 city        dates      │ value
 ───────────────────────┼──────
@@ -70,26 +87,8 @@ city        dates      │ value
 
 julia> t2["Boston", Date(2016, 7, 6)]
 (value = 95)
-
-julia> first(t2)
-(value = 95)
-```
-
-As with other multi-dimensional arrays, dimensions can be permuted to change the sort order:
-
-```julia
-julia> permutedims(t2, [2,1])
-2-d NDSparse with 6 values (1 field named tuples):
-dates       city       │ value
-───────────────────────┼──────
-2016-07-06  "Boston"   │ 95
-2016-07-06  "New York" │ 91
-2016-07-07  "Boston"   │ 83
-2016-07-07  "New York" │ 89
-2016-07-08  "Boston"   │ 76
-2016-07-08  "New York" │ 91
 ```
 
 ## Get started
 
-For more information, check out the [JuliaDB API Reference](http://juliadb.org/latest/api/datastructures.html).
+For more information, check out the [JuliaDB Documentation](http://juliadb.org/latest/index.html).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ IndexedTables offers two data structures: `IndexedTable` and `NDSparse`.
 
 - **Both types store data _in columns_**.
 - **`IndexedTable` and `NDSparse` differ mainly in how data is accessed.**
-- **Both types have equal performance fr Table operations (`select`, `filter`, etc.).** 
+- **Both types have equal performance for Table operations (`select`, `filter`, etc.).** 
 
 
 ## Quickstart

--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ TableTraits 0.3.0
 TableTraitsUtils 0.2.0
 IteratorInterfaceExtensions 0.1.0
 DataValues
+Tables

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -33,7 +33,7 @@ const DimName = Union{Int,Symbol}
 
 include("utils.jl")
 include("columns.jl")
-include("table.jl")
+include("indexedtable.jl")
 include("ndsparse.jl")
 include("collect.jl")
 

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -23,7 +23,7 @@ export
     AbstractNDSparse, All, ApplyColwise, Between, ColDict, Columns, IndexedTable,
     Keys, NDSparse, NextTable, Not,
     # functions
-    aggregate, aggregate!, aggregate_vec, antijoin, asofjoin, collect_columns, colnames,
+    aggregate!, antijoin, asofjoin, collect_columns, colnames,
     column, columns, convertdim, dimlabels, dropna, flatten, flush!, groupby, groupjoin,
     groupreduce, innerjoin, insertafter!, insertbefore!, insertcol, insertcolafter, 
     insertcolbefore, leftgroupjoin, leftjoin, map_rows, naturalgroupjoin, naturaljoin,

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -6,11 +6,14 @@ using PooledArrays, SparseArrays, Statistics, WeakRefStrings, TableTraits,
 using OnlineStatsBase: OnlineStat, fit!
 using DataValues: DataValues, DataValue, NA, isna, DataValueArray
 import DataValues: dropna
+import Tables
 
 import Base:
     show, eltype, length, getindex, setindex!, ndims, map, convert, keys, values,
     ==, broadcast, empty!, copy, similar, sum, merge, merge!, mapslices,
-    permutedims, sort, sort!, iterate, pairs
+    permutedims, sort, sort!, iterate, pairs, reduce, push!, size, permute!, issorted, 
+    sortperm, summary, resize!, vcat, append!, copyto!, view
+
 
 #-----------------------------------------------------------------------# exports
 export 
@@ -75,5 +78,6 @@ include("reshape.jl")
 
 # TableTraits.jl integration
 include("tabletraits.jl")
+include("tables.jl")
 
 end # module

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -1,7 +1,3 @@
-import Base:
-    push!, size, sort, sort!, permute!, issorted, sortperm,
-    summary, resize!, vcat, append!, copyto!, view
-
 """
 Wrapper around a (named) tuple of Vectors that acts like a Vector of (named) tuples.
 

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -106,17 +106,14 @@ length(c::Columns{<:Pair, <:Pair}) = length(c.columns.first)
 ndims(c::Columns) = 1
 
 """
-`ncols(itr)`
+    ncols(itr)
 
 Returns the number of columns in `itr`.
 
 # Examples
 
-    ncols([1,2,3])
-    ncols(rows(([1,2,3],[4,5,6])))
-    ncols(table(([1,2,3],[4,5,6])))
-    ncols(table(@NT(x=[1,2,3],y=[4,5,6])))
-    ncols(ndsparse(d, [7,8,9]))
+    ncols([1,2,3]) == 1
+    ncols(rows(([1,2,3],[4,5,6]))) == 2
 """
 function ncols end
 ncols(c::Columns) = fieldcount(typeof(c.columns))

--- a/src/indexedtable.jl
+++ b/src/indexedtable.jl
@@ -16,7 +16,7 @@ end
 abstract type AbstractIndexedTable end
 
 """
-A tabular data structure that extends [`Columns`](@ref).  Create a `IndexedTable` with the 
+A tabular data structure that extends [`Columns`](@ref).  Create an `IndexedTable` with the 
 [`table`](@ref) function.
 """
 struct IndexedTable{C<:Columns} <: AbstractIndexedTable

--- a/src/indexedtable.jl
+++ b/src/indexedtable.jl
@@ -1,5 +1,3 @@
-import Base: setindex!, reduce
-
 """
 A permutation
 

--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -391,7 +391,7 @@ end
 # aggregation
 
 """
-`aggregate!(f::Function, arr::NDSparse)`
+    aggregate!(f::Function, arr::NDSparse)
 
 Combine adjacent rows with equal indices using the given 2-argument reduction function,
 in place.

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -41,10 +41,20 @@ end
     getfield(columns(t), which)
 end
 
+"""
+    selectkeys(x::NDSparse, sel)
+
+Return an `NDSparse` with a subset of keys.
+"""
 function selectkeys(x::NDSparse, which; kwargs...)
     ndsparse(rows(keys(x), which), values(x); kwargs...)
 end
 
+"""
+    selectvalues(x::NDSparse, sel)
+
+Return an `NDSparse` with a subset of values
+"""
 function selectvalues(x::NDSparse, which; presorted=true, copy=false, kwargs...)
     ndsparse(keys(x), rows(values(x), which); presorted=presorted, copy=copy, kwargs...)
 end

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,0 +1,26 @@
+#-----------------------------------------------------------------------# Columns 
+const TableColumns = Columns{T} where {T<:NamedTuple}
+
+Tables.istable(::Type{<:TableColumns}) = true
+Tables.materializer(c::TableColumns) = Columns
+
+Tables.rowaccess(c::TableColumns) = true
+Tables.rows(c::TableColumns) = c
+Tables.schema(c::TableColumns) = Tables.Schema(colnames(c), Tuple(map(eltype, c.columns)))
+
+Tables.columnaccess(c::TableColumns) = true
+Tables.columns(c::TableColumns) = c.columns
+# Tables.schema already defined for NamedTuple of Vectors (c.columns)
+
+#-----------------------------------------------------------------------# IndexedTable/NDSparse
+Tables.istable(::Type{IndexedTable{C}}) where {C<:TableColumns} = true
+Tables.istable(::Type{NDSparse{T,D,C,V}}) where {T,D,C<:TableColumns,V<:TableColumns} = true
+
+Tables.materializer(t::IndexedTable) = table
+Tables.materializer(t::NDSparse) = ndpsarse
+
+for f in [:rowaccess, :rows, :columnaccess, :columns, :schema]
+    @eval Tables.$f(t::Dataset) = Tables.$f(Columns(columns(t)))
+end
+
+

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,6 +1,5 @@
 #-----------------------------------------------------------------------# Columns 
 const TableColumns = Columns{T} where {T<:NamedTuple}
-Columns(x) = Columns(Tables.columntable(x))
 
 Columns(x; kw...) = Columns(Tables.columntable(x); kw...)
 

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,6 +1,8 @@
 #-----------------------------------------------------------------------# Columns 
 const TableColumns = Columns{T} where {T<:NamedTuple}
 
+Columns(x; kw...) = Columns(Tables.columntable(x); kw...)
+
 Tables.istable(::Type{<:TableColumns}) = true
 Tables.materializer(c::TableColumns) = Columns
 
@@ -14,13 +16,15 @@ Tables.columns(c::TableColumns) = c.columns
 
 #-----------------------------------------------------------------------# IndexedTable/NDSparse
 Tables.istable(::Type{IndexedTable{C}}) where {C<:TableColumns} = true
-Tables.istable(::Type{NDSparse{T,D,C,V}}) where {T,D,C<:TableColumns,V<:TableColumns} = true
-
 Tables.materializer(t::IndexedTable) = table
-Tables.materializer(t::NDSparse) = ndpsarse
-
 for f in [:rowaccess, :rows, :columnaccess, :columns, :schema]
-    @eval Tables.$f(t::Dataset) = Tables.$f(Columns(columns(t)))
+    @eval Tables.$f(t::IndexedTable) = Tables.$f(Columns(columns(t)))
 end
+
+#-----------------------------------------------------------------------# NDSparse
+# Tables.istable(::Type{NDSparse{T,D,C,V}}) where {T,D,C<:TableColumns,V<:TableColumns} = true
+# Tables.materializer(t::NDSparse) = ndpsarse
+
+
 
 

--- a/src/tabletraits.jl
+++ b/src/tabletraits.jl
@@ -52,10 +52,10 @@ function table(rows::AbstractArray{T}; copy=false, kwargs...) where {T<:Union{Tu
     table(collect_columns(rows); copy=false, kwargs...)
 end
 
-function table(iter; copy=false, kwargs...)
+function table(iter; copy=false, kw...)
     if TableTraits.isiterable(iter)
-        table(collect_columns(getiterator(iter)); copy=false, kwargs...)
+        table(collect_columns(getiterator(iter)); copy=copy, kw...)
     else
-        throw(ArgumentError("iter cannot be turned into a IndexedTable."))
+        table(Tables.columntable(iter); copy=copy, kw...)
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -161,7 +161,7 @@ function namedtuple(fields...)
 end
 
 """
-`arrayof(T)`
+    arrayof(T)
 
 Returns the type of `Columns` or `Vector` suitable to store
 values of type T. Nested tuples beget nested Columns.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,8 @@
-using Test, IndexedTables, OnlineStats, DataValues, WeakRefStrings
+using Test, IndexedTables, OnlineStats, DataValues, WeakRefStrings, Tables
 import DataValues: NA
 
-@testset "IndexedTables" begin
-
-include("test_core.jl")
-include("test_utils.jl")
-include("test_tabletraits.jl")
-include("test_collect.jl")
-
-end
+include("test_tables.jl")
+# include("test_core.jl")
+# include("test_utils.jl")
+# include("test_tabletraits.jl")
+# include("test_collect.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Test, IndexedTables, OnlineStats, DataValues, WeakRefStrings, Tables
 import DataValues: NA
 
 include("test_tables.jl")
-# include("test_core.jl")
-# include("test_utils.jl")
-# include("test_tabletraits.jl")
-# include("test_collect.jl")
+include("test_core.jl")
+include("test_utils.jl")
+include("test_tabletraits.jl")
+include("test_collect.jl")

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -1,0 +1,20 @@
+
+
+
+@testset "Tables Interface" begin 
+    n = 1000
+    x, y, z = 1:n, rand(Bool, n), randn(n)
+
+    t = table((x=x, y=y, z=z), pkey=[:x, :y])
+    nd = ndsparse((x=x, y=y), (z=z,))
+
+    @test Tables.istable(t)
+    @test Tables.istable(nd)
+    @test Tables.istable(columns(t))
+    @test Tables.istable(Columns(columns(t)))
+    @test t == table(ndsparse(t))
+    @test nd == ndsparse(table(nd))
+    for (t_row, nd_row) in zip(rows(t), rows(nd))
+        @test t_row == nd_row
+    end
+end

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -6,15 +6,8 @@
     x, y, z = 1:n, rand(Bool, n), randn(n)
 
     t = table((x=x, y=y, z=z), pkey=[:x, :y])
-    nd = ndsparse((x=x, y=y), (z=z,))
 
     @test Tables.istable(t)
-    @test Tables.istable(nd)
     @test Tables.istable(columns(t))
     @test Tables.istable(Columns(columns(t)))
-    @test t == table(ndsparse(t))
-    @test nd == ndsparse(table(nd))
-    for (t_row, nd_row) in zip(rows(t), rows(nd))
-        @test t_row == nd_row
-    end
 end


### PR DESCRIPTION
This PR:

- Adds `tables.jl` which provides the Tables integration
- renames `table.jl` -> `indexedtable.jl` to avoid confusion

My approach is to define the Tables interface for `Columns`, which provides the basis for integrating `IndexedTable` and `NDSparse`.

@quinnj : I haven't been following Tables development closely enough.  Is this sufficient to remove the TableTraits/TableTraitsUtils/IteratorInterfaceExtensions dependencies?