### PR TITLE
WIP: Transition to Missing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,3 +12,9 @@
 - **(feature)** - `collect_columns` function to collect an iterator of tuples to `Columns` object. (#135)
 - **(bugfix)** use `collect_columns` to implement `map`, `groupreduce` and `groupjoin` (#150) to not depend on type inference. Works in many more cases.
 - **(feature)** - `view` works with logical indexes now (#134)
+
+
+## v0.9.0
+
+- **(breaking)** Switch from DataValues to Missing.  Related: `dropna` has been changed to `dropmissing`.
+- **(breaking)** Depend on OnlineStatsBase rather than OnlineStats. 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,28 @@ be used on its own for efficient in-memory data processing and analytics.
 
 ## Data Structures 
 
-- **The two table types in IndexedTables differ in how data is accessed.**
-- **There is no performance difference between table types for operations such as selecting, filtering, and map/reduce.**
+IndexedTables offers two data structures: `IndexedTable` and `NDSparse`.
+
+- **Both types store data _in columns_**.
+- **`IndexedTable` and `NDSparse` differ mainly in how data is accessed.**
+- **Both types have equal performance fr Table operations (`select`, `filter`, etc.).** 
+
+
+## Quickstart
+
+```
+using Pkg
+Pkg.add("IndexedTables")
+using IndexedTables
+
+t = table((x = 1:100, y = randn(100)))
+
+select(t, :x)
+
+filter(row -> row.y > 0, t)
+```
+
+## `IndexedTable` vs. `NDSparse`
 
 First let's create some data to work with.
 
@@ -22,18 +42,18 @@ city = vcat(fill("New York", 3), fill("Boston", 3))
 
 dates = repeat(Date(2016,7,6):Day(1):Date(2016,7,8), 2)
 
-values = [91, 89, 91, 95, 83, 76]
+vals = [91, 89, 91, 95, 83, 76]
 ```
 
-### Table
+### IndexedTable
 
-- Data is accessed as a Vector of NamedTuples.  
-- Sorted by primary key(s), `pkey`.
+- (Optionally) Sorted by primary key(s), `pkey`.
+- Data is accessed as a Vector of NamedTuples.
 
 ```julia
 using IndexedTables
 
-julia> t1 = table((city = city, dates = dates, values = values); pkey = [:city, :dates])
+julia> t1 = table((city = city, dates = dates, values = vals); pkey = [:city, :dates])
 Table with 6 rows, 3 columns:
 city        dates       values
 ──────────────────────────────
@@ -46,18 +66,15 @@ city        dates       values
 
 julia> t1[1]
 (city = "Boston", dates = 2016-07-06, values = 95)
-
-julia> first(t1)
-(city = "Boston", dates = 2016-07-06, values = 95)
 ```
 
 ### NDSparse
 
-- Data is accessed as an N-dimensional sparse array with arbitrary indexes.
 - Sorted by index variables (first argument).
+- Data is accessed as an N-dimensional sparse array with arbitrary indexes.
 
 ```julia
-julia> t2 = ndsparse(@NT(city=city, dates=dates), @NT(value=values))
+julia> t2 = ndsparse((city=city, dates=dates), (value=vals,))
 2-d NDSparse with 6 values (1 field named tuples):
 city        dates      │ value
 ───────────────────────┼──────
@@ -70,26 +87,8 @@ city        dates      │ value
 
 julia> t2["Boston", Date(2016, 7, 6)]
 (value = 95)
-
-julia> first(t2)
-(value = 95)
-```
-
-As with other multi-dimensional arrays, dimensions can be permuted to change the sort order:
-
-```julia
-julia> permutedims(t2, [2,1])
-2-d NDSparse with 6 values (1 field named tuples):
-dates       city       │ value
-───────────────────────┼──────
-2016-07-06  "Boston"   │ 95
-2016-07-06  "New York" │ 91
-2016-07-07  "Boston"   │ 83
-2016-07-07  "New York" │ 89
-2016-07-08  "Boston"   │ 76
-2016-07-08  "New York" │ 91
 ```
 
 ## Get started
 
-For more information, check out the [JuliaDB API Reference](http://juliadb.org/latest/api/datastructures.html).
+For more information, check out the [JuliaDB Documentation](http://juliadb.org/latest/index.html).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ IndexedTables offers two data structures: `IndexedTable` and `NDSparse`.
 
 - **Both types store data _in columns_**.
 - **`IndexedTable` and `NDSparse` differ mainly in how data is accessed.**
-- **Both types have equal performance fr Table operations (`select`, `filter`, etc.).** 
+- **Both types have equal performance for Table operations (`select`, `filter`, etc.).** 
 
 
 ## Quickstart

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,5 +5,4 @@ WeakRefStrings 0.4.4
 TableTraits 0.3.0
 TableTraitsUtils 0.2.0
 IteratorInterfaceExtensions 0.1.0
-DataValues
 Tables

--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ TableTraits 0.3.0
 TableTraitsUtils 0.2.0
 IteratorInterfaceExtensions 0.1.0
 DataValues
+Tables

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -33,7 +33,7 @@ const DimName = Union{Int,Symbol}
 
 include("utils.jl")
 include("columns.jl")
-include("table.jl")
+include("indexedtable.jl")
 include("ndsparse.jl")
 include("collect.jl")
 

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -23,7 +23,7 @@ export
     Keys, NDSparse, NextTable, Not,
     # functions
     aggregate!, antijoin, asofjoin, collect_columns, colnames,
-    column, columns, convertdim, dimlabels, dropna, flatten, flush!, groupby, groupjoin,
+    column, columns, convertdim, dimlabels, flatten, flush!, groupby, groupjoin,
     groupreduce, innerjoin, insertafter!, insertbefore!, insertcol, insertcolafter, 
     insertcolbefore, leftgroupjoin, leftjoin, map_rows, naturalgroupjoin, naturaljoin,
     ncols, ndsparse, outergroupjoin, outerjoin, pkeynames, pkeys, popcol, pushcol,

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -4,8 +4,6 @@ using PooledArrays, SparseArrays, Statistics, WeakRefStrings, TableTraits,
     TableTraitsUtils, IteratorInterfaceExtensions
 
 using OnlineStatsBase: OnlineStat, fit!
-using DataValues: DataValues, DataValue, NA, isna, DataValueArray
-# import DataValues: dropna
 import Tables
 
 import Base:

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -12,7 +12,8 @@ import Base:
     show, eltype, length, getindex, setindex!, ndims, map, convert, keys, values,
     ==, broadcast, empty!, copy, similar, sum, merge, merge!, mapslices,
     permutedims, sort, sort!, iterate, pairs, reduce, push!, size, permute!, issorted, 
-    sortperm, summary, resize!, vcat, append!, copyto!, view
+    sortperm, summary, resize!, vcat, append!, copyto!, view, tail,
+    tuple_type_cons, tuple_type_head, tuple_type_tail, in, convert
 
 
 #-----------------------------------------------------------------------# exports
@@ -29,7 +30,7 @@ export
     insertcolbefore, leftgroupjoin, leftjoin, map_rows, naturalgroupjoin, naturaljoin,
     ncols, ndsparse, outergroupjoin, outerjoin, pkeynames, pkeys, popcol, pushcol,
     reducedim_vec, reindex, renamecol, rows, select, selectkeys, selectvalues, setcol,
-    stack, summarize, table, unstack, update!, where
+    stack, summarize, table, unstack, update!, where, dropmissing
 
 const Tup = Union{Tuple,NamedTuple}
 const DimName = Union{Int,Symbol}
@@ -76,7 +77,7 @@ include("flatten.jl")
 include("join.jl")
 include("reshape.jl")
 
-# TableTraits.jl integration
+# TableTraits/Tables integration
 include("tabletraits.jl")
 include("tables.jl")
 

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -23,7 +23,7 @@ export
     AbstractNDSparse, All, ApplyColwise, Between, ColDict, Columns, IndexedTable,
     Keys, NDSparse, NextTable, Not,
     # functions
-    aggregate, aggregate!, aggregate_vec, antijoin, asofjoin, collect_columns, colnames,
+    aggregate!, antijoin, asofjoin, collect_columns, colnames,
     column, columns, convertdim, dimlabels, dropna, flatten, flush!, groupby, groupjoin,
     groupreduce, innerjoin, insertafter!, insertbefore!, insertcol, insertcolafter, 
     insertcolbefore, leftgroupjoin, leftjoin, map_rows, naturalgroupjoin, naturaljoin,

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -5,7 +5,7 @@ using PooledArrays, SparseArrays, Statistics, WeakRefStrings, TableTraits,
 
 using OnlineStatsBase: OnlineStat, fit!
 using DataValues: DataValues, DataValue, NA, isna, DataValueArray
-import DataValues: dropna
+# import DataValues: dropna
 import Tables
 
 import Base:

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -6,11 +6,14 @@ using PooledArrays, SparseArrays, Statistics, WeakRefStrings, TableTraits,
 using OnlineStatsBase: OnlineStat, fit!
 using DataValues: DataValues, DataValue, NA, isna, DataValueArray
 import DataValues: dropna
+import Tables
 
 import Base:
     show, eltype, length, getindex, setindex!, ndims, map, convert, keys, values,
     ==, broadcast, empty!, copy, similar, sum, merge, merge!, mapslices,
-    permutedims, sort, sort!, iterate, pairs
+    permutedims, sort, sort!, iterate, pairs, reduce, push!, size, permute!, issorted, 
+    sortperm, summary, resize!, vcat, append!, copyto!, view
+
 
 #-----------------------------------------------------------------------# exports
 export 
@@ -75,5 +78,6 @@ include("reshape.jl")
 
 # TableTraits.jl integration
 include("tabletraits.jl")
+include("tables.jl")
 
 end # module

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -28,7 +28,7 @@ export
     insertcolbefore, leftgroupjoin, leftjoin, map_rows, naturalgroupjoin, naturaljoin,
     ncols, ndsparse, outergroupjoin, outerjoin, pkeynames, pkeys, popcol, pushcol,
     reducedim_vec, reindex, renamecol, rows, select, selectkeys, selectvalues, setcol,
-    stack, summarize, table, unstack, update!, where, dropmissing
+    stack, summarize, table, unstack, update!, where, dropmissing, dropna
 
 const Tup = Union{Tuple,NamedTuple}
 const DimName = Union{Int,Symbol}

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -1,6 +1,6 @@
 _is_subtype(::Type{S}, ::Type{T}) where {S, T} = promote_type(S, T) == T
 
-dataarrayof(::Type{<:DataValue{T}}, len) where {T} = DataValueArray{T,1}(len)
+# dataarrayof(::Type{<:DataValue{T}}, len) where {T} = DataValueArray{T,1}(len)
 dataarrayof(::Type{T}, len) where {T} = Vector{T}(undef, len)
 
 """

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -1,8 +1,5 @@
 _is_subtype(::Type{S}, ::Type{T}) where {S, T} = promote_type(S, T) == T
 
-# dataarrayof(::Type{<:DataValue{T}}, len) where {T} = DataValueArray{T,1}(len)
-dataarrayof(::Type{T}, len) where {T} = Vector{T}(undef, len)
-
 """
     collect_columns(itr)
 
@@ -166,7 +163,7 @@ function widencolumns(dest, i, el::S, ::Type{T}) where{S <: Tup, T<:Tup}
         idx = findall(collect(!(s <: t) for (s, t) in zip(sp, tp)))
         new = dest
         for l in idx
-            newcol = dataarrayof(promote_type(sp[l], tp[l]), length(dest))
+            newcol = Vector{promote_type(sp[l], tp[l])}(undef, length(dest))
             copyto!(newcol, 1, column(dest, l), 1, i-1)
             new = setcol(new, l, newcol)
         end
@@ -175,7 +172,7 @@ function widencolumns(dest, i, el::S, ::Type{T}) where{S <: Tup, T<:Tup}
 end
 
 function widencolumns(dest, i, el::S, ::Type{T}) where{S, T}
-    new = dataarrayof(promote_type(S, T), length(dest))
+    new = Vector{promote_type(S, T)}(undef, length(dest))
     copyto!(new, 1, dest, 1, i-1)
     new
 end

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -1,7 +1,3 @@
-import Base:
-    push!, size, sort, sort!, permute!, issorted, sortperm,
-    summary, resize!, vcat, append!, copyto!, view
-
 """
 Wrapper around a (named) tuple of Vectors that acts like a Vector of (named) tuples.
 

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -181,10 +181,9 @@ function ==(x::Columns, y::Columns)
     nc = length(x.columns)
     length(y.columns) == nc || return false
     fieldnames(eltype(x)) == fieldnames(eltype(y)) || return false
-    n = length(x)
-    length(y) == n || return false
-    for i in 1:nc
-        x.columns[i] == y.columns[i] || return false
+    length(y) == length(x) || return false
+    for (xi, yi) in zip(x.columns, y.columns)
+        all(r -> r[1] === r[2] || r[1] == r[2], zip(xi, yi)) || return false
     end
     return true
 end

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -427,7 +427,7 @@ struct Between{T1 <: Union{Int, Symbol}, T2 <: Union{Int, Symbol}}
     last::T2
 end
 
-const SpecialSelector = Union{Not, All, Keys, Between, Function, Regex}
+const SpecialSelector = Union{Not, All, Keys, Between, Function, Regex, Type}
 
 hascolumns(t, s) = true
 hascolumns(t, s::Symbol) = s in colnames(t)
@@ -436,6 +436,7 @@ hascolumns(t, s::Tuple) = all(hascolumns(t, x) for x in s)
 hascolumns(t, s::Not) = hascolumns(t, s.cols)
 hascolumns(t, s::Between) = hascolumns(t, s.first) && hascolumns(t, s.last)
 hascolumns(t, s::All) = all(hascolumns(t, x) for x in s.cols)
+hascolumns(t, s::Type) = any(x -> eltype(x) <: s, columns(t))
 
 lowerselection(t, s)                     = s
 lowerselection(t, s::Union{Int, Symbol}) = colindex(t, s)
@@ -445,6 +446,7 @@ lowerselection(t, s::Keys)               = lowerselection(t, IndexedTables.pkeyn
 lowerselection(t, s::Between)            = Tuple(colindex(t, s.first):colindex(t, s.last))
 lowerselection(t, s::Function)           = colindex(t, Tuple(filter(s, collect(colnames(t)))))
 lowerselection(t, s::Regex)              = lowerselection(t, x -> occursin(s, string(x)))
+lowerselection(t, s::Type)               = Tuple(findall(x -> eltype(x) <: s, columns(t)))
 
 function lowerselection(t, s::All)
     s.cols == () && return lowerselection(t, valuenames(t))

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -182,9 +182,15 @@ function ==(x::Columns, y::Columns)
     fieldnames(eltype(x)) == fieldnames(eltype(y)) || return false
     length(y) == length(x) || return false
     for (xi, yi) in zip(x.columns, y.columns)
-        allequal = (xi == yi) 
-        ismissing(allequal) && return false
-        allequal || return false
+        for (xij, yij) in zip(xi, yi)
+            eq = xij == yij
+            if ismissing(eq)
+                ismissing(xij) && ismissing(yij) || return false
+            else
+
+                eq || return false
+            end
+        end
     end
     return true
 end

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -178,12 +178,13 @@ resize!(I::Columns, n::Int) = (foreach(c->resize!(c,n), I.columns); I)
 _sizehint!(c::Columns, n::Integer) = (foreach(c->_sizehint!(c,n), c.columns); c)
 
 function ==(x::Columns, y::Columns)
-    nc = length(x.columns)
-    length(y.columns) == nc || return false
+    length(y.columns) == length(x.columns) || return false
     fieldnames(eltype(x)) == fieldnames(eltype(y)) || return false
     length(y) == length(x) || return false
     for (xi, yi) in zip(x.columns, y.columns)
-        all(r -> r[1] === r[2] || r[1] == r[2], zip(xi, yi)) || return false
+        allequal = (xi == yi) 
+        ismissing(allequal) && return false
+        allequal || return false
     end
     return true
 end

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -106,17 +106,14 @@ length(c::Columns{<:Pair, <:Pair}) = length(c.columns.first)
 ndims(c::Columns) = 1
 
 """
-`ncols(itr)`
+    ncols(itr)
 
 Returns the number of columns in `itr`.
 
 # Examples
 
-    ncols([1,2,3])
-    ncols(rows(([1,2,3],[4,5,6])))
-    ncols(table(([1,2,3],[4,5,6])))
-    ncols(table(@NT(x=[1,2,3],y=[4,5,6])))
-    ncols(ndsparse(d, [7,8,9]))
+    ncols([1,2,3]) == 1
+    ncols(rows(([1,2,3],[4,5,6]))) == 2
 """
 function ncols end
 ncols(c::Columns) = fieldcount(typeof(c.columns))

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -93,7 +93,6 @@ available selection options and syntax.
 """
 function columns end
 
-# columns(c) = error("no columns defined for $(typeof(c))")
 columns(c::Columns) = c.columns
 
 # Array-like API

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -93,7 +93,7 @@ available selection options and syntax.
 """
 function columns end
 
-columns(c) = error("no columns defined for $(typeof(c))")
+# columns(c) = error("no columns defined for $(typeof(c))")
 columns(c::Columns) = c.columns
 
 # Array-like API
@@ -177,27 +177,7 @@ resize!(I::Columns, n::Int) = (foreach(c->resize!(c,n), I.columns); I)
 
 _sizehint!(c::Columns, n::Integer) = (foreach(c->_sizehint!(c,n), c.columns); c)
 
-function ==(x::Columns, y::Columns)
-    length(y.columns) == length(x.columns) || return false
-    fieldnames(eltype(x)) == fieldnames(eltype(y)) || return false
-    length(y) == length(x) || return false
-    for (xi, yi) in zip(x.columns, y.columns)
-        for (xij, yij) in zip(xi, yi)
-            eq = xij == yij
-            if ismissing(eq)
-                ismissing(xij) && ismissing(yij) || return false
-            else
-
-                eq || return false
-            end
-        end
-    end
-    return true
-end
-
-==(x::Columns{<:Pair}, y::Columns) = false
-==(x::Columns, y::Columns{<:Pair}) = false
-==(x::Columns{<:Pair}, y::Columns{<:Pair}) = (x.columns.first == y.columns.first) && (x.columns.second == y.columns.second)
+==(x::Columns, y::Columns) = isequal(x, y)
 
 function _strip_pair(c::Columns{<:Pair})
     f, s = map(columns, c.columns)
@@ -367,7 +347,7 @@ end
 # map
 
 """
-`map_rows(f, c...)`
+    map_rows(f, c...)
 
 Transform collection `c` by applying `f` to each element. For multiple collection arguments, apply `f`
 elementwise. Collect output as `Columns` if `f` returns

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -176,7 +176,7 @@ resize!(I::Columns, n::Int) = (foreach(c->resize!(c,n), I.columns); I)
 
 _sizehint!(c::Columns, n::Integer) = (foreach(c->_sizehint!(c,n), c.columns); c)
 
-==(x::Columns, y::Columns) = isequal(x, y)
+==(x::Columns, y::Columns) = x.columns == y.columns
 
 function _strip_pair(c::Columns{<:Pair})
     f, s = map(columns, c.columns)

--- a/src/indexedtable.jl
+++ b/src/indexedtable.jl
@@ -371,8 +371,9 @@ Names of all columns in `itr` except `cols`. `itr` can be any of
 """
 excludecols(t, cols) = excludecols(t, (cols,))
 excludecols(t, cols::SpecialSelector) = excludecols(t, lowerselection(t, cols))
-excludecols(t, cols::Tuple) = Tuple(setdiff(1:length(colnames(t)), colindex.(Ref(t), cols)))
-
+function excludecols(t, cols::Tuple) 
+    Tuple(setdiff(1:length(colnames(t)), map(x -> colindex(t, x), cols)))
+end
 
 """
     convert(IndexedTable, pkeys, vals; kwargs...)

--- a/src/indexedtable.jl
+++ b/src/indexedtable.jl
@@ -353,7 +353,7 @@ function sort!(t::IndexedTable, by...; kwargs...)
 end
 
 """
-    excludecols(itr, cols)
+    excludecols(itr, cols) -> Tuple of Int
 
 Names of all columns in `itr` except `cols`. `itr` can be any of
 `Table`, `NDSparse`, `Columns`, or `AbstractVector`
@@ -369,23 +369,10 @@ Names of all columns in `itr` except `cols`. `itr` can be any of
     excludecols(t, pkeynames(t))
     excludecols([1,2,3], (1,))
 """
-function excludecols(t, cols)
-    if cols isa SpecialSelector
-        return excludecols(t, lowerselection(t, cols))
-    end
-    if !isa(cols, Tuple)
-        return excludecols(t, (cols,))
-    end
-    ns = colnames(t)
-    mask = ones(Bool, length(ns))
-    for c in cols
-        i = colindex(t, c)
-        if i !== 0
-            mask[i] = false
-        end
-    end
-    ((1:length(ns))[mask]...,)
-end
+excludecols(t, cols) = excludecols(t, (cols,))
+excludecols(t, cols::SpecialSelector) = excludecols(t, lowerselection(t, cols))
+excludecols(t, cols::Tuple) = Tuple(setdiff(1:length(colnames(t)), colindex.(Ref(t), cols)))
+
 
 """
     convert(IndexedTable, pkeys, vals; kwargs...)

--- a/src/indexedtable.jl
+++ b/src/indexedtable.jl
@@ -16,7 +16,7 @@ end
 abstract type AbstractIndexedTable end
 
 """
-A tabular data structure that extends [`Columns`](@ref).  Create a `IndexedTable` with the 
+A tabular data structure that extends [`Columns`](@ref).  Create an `IndexedTable` with the 
 [`table`](@ref) function.
 """
 struct IndexedTable{C<:Columns} <: AbstractIndexedTable

--- a/src/indexedtable.jl
+++ b/src/indexedtable.jl
@@ -1,5 +1,3 @@
-import Base: setindex!, reduce
-
 """
 A permutation
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -19,7 +19,6 @@ _in(x, v::AbstractString) = x == v
 _in(x, v::Symbol) = x === v
 _in(x, v::Number) = isequal(x, v)
 
-import Base: tail
 # test whether row r is within product(idxs...)
 @inline row_in(cs, r::Integer, idxs) = _row_in(cs[1], r, idxs[1], tail(cs), tail(idxs))
 @inline _row_in(c1, r, i1, rI, ri) = _in(c1[r],i1) & _row_in(rI[1], r, ri[1], tail(rI), tail(ri))

--- a/src/join.jl
+++ b/src/join.jl
@@ -181,7 +181,6 @@ function init_join_output(typ, grp, f, ldata, rdata, left, keepkeys, lkey, rkey,
 
         left_type = eltype(ldata)
         if !isa(typ, Union{Val{:left}, Val{:inner}, Val{:anti}})
-            # null_left_type = map_params(x->DataValue{x}, eltype(ldata))
             null_left_type = map_params(x -> Union{Missing, x}, eltype(ldata))
             lnull = nullrow(null_left_type)
         else
@@ -190,7 +189,6 @@ function init_join_output(typ, grp, f, ldata, rdata, left, keepkeys, lkey, rkey,
 
         right_type = eltype(rdata)
         if !isa(typ, Val{:inner})
-            # null_right_type = map_params(x->DataValue{x}, eltype(rdata))
             null_right_type = map_params(x->Union{Missing, x}, eltype(rdata))
             rnull = nullrow(null_right_type)
         else
@@ -345,11 +343,6 @@ function Base.join(f, left::Dataset, right::Dataset;
         lnulls[lnull_idx] .= true
         lout = if lout isa Columns
             Columns(map(lout.columns) do col
-                        # if col isa DataValueArray
-                        #     col.isna[lnull_idx] .= true
-                        # else
-                        #     DataValueArray(col, lnulls)
-                        # end
                 v = Vector{Union{Missing,eltype(col)}}(col)
                 v[lnull_idx] .= missing
                 v
@@ -358,11 +351,6 @@ function Base.join(f, left::Dataset, right::Dataset;
             v = Vector{Union{Missing, eltype(lout)}}(lout)
             v[lnull_idx] .= missing
             v
-            # if lout isa DataValueArray
-            #     lout.isna[lnull_idx] .= true
-            # else
-            #     DataValueArray(lout, lnulls)
-            # end
         end
         data = concat_cols(lout, rout)
     end
@@ -372,11 +360,6 @@ function Base.join(f, left::Dataset, right::Dataset;
         rnulls[rnull_idx] .= true
         rout = if rout isa Columns
             Columns(map(rout.columns) do col
-                        # if col isa DataValueArray
-                        #     col.isna[rnull_idx] .= true
-                        # else
-                        #     DataValueArray(col, rnulls)
-                        # end
                 v = Vector{Union{Missing,eltype(col)}}(col)
                 v[rnull_idx] .= missing
                 v
@@ -385,11 +368,6 @@ function Base.join(f, left::Dataset, right::Dataset;
             v = Vector{Union{Missing,eltype(rout)}}(rout)
             v[rnull_idx] .= missing
             v
-            # if rout isa DataValueArray
-            #     rout.isna[rnull_idx] .= true
-            # else
-            #     DataValueArray(rout, rnulls)
-            # end
         end
         data = concat_cols(lout, rout)
     end

--- a/src/join.jl
+++ b/src/join.jl
@@ -102,7 +102,7 @@ function _join!(::Val{typ}, ::Val{grp}, ::Val{keepkeys}, f, I, data, ks, lout, r
                             # optimized push! method for concat_tup
                             _push!(Val{:both}(), f, data,
                                    lout, rout, ldata, rdata,
-                                   lperm[x], rperm[y], NA, NA)
+                                   lperm[x], rperm[y], missing, missing)
                         end
                     end
                 else
@@ -167,9 +167,9 @@ function _join!(::Val{typ}, ::Val{grp}, ::Val{keepkeys}, f, I, data, ks, lout, r
     lnull_idx, rnull_idx
 end
 
-nullrow(::Type{T}) where {T <: Tuple} = Tuple(fieldtype(T, i)() for i = 1:fieldcount(T))
-nullrow(::Type{NamedTuple{names, T}}) where {names, T} = NamedTuple{names, T}(Tuple(fieldtype(T, i)() for i = 1:fieldcount(T)))
-nullrow(t::Type{<:DataValue}) = t()
+nullrow(t::Type{<:Tuple}) = Tuple(map(x->missing, fieldtypes(t)))
+nullrow(t::Type{<:NamedTuple}) = t(Tuple(map(x->missing, fieldtypes(t))))
+nullrow(t) = missing
 
 function init_join_output(typ, grp, f, ldata, rdata, left, keepkeys, lkey, rkey, init_group, accumulate)
     lnull = nothing
@@ -181,7 +181,8 @@ function init_join_output(typ, grp, f, ldata, rdata, left, keepkeys, lkey, rkey,
 
         left_type = eltype(ldata)
         if !isa(typ, Union{Val{:left}, Val{:inner}, Val{:anti}})
-            null_left_type = map_params(x->DataValue{x}, eltype(ldata))
+            # null_left_type = map_params(x->DataValue{x}, eltype(ldata))
+            null_left_type = map_params(x -> Union{Missing, x}, eltype(ldata))
             lnull = nullrow(null_left_type)
         else
             null_left_type = left_type
@@ -189,7 +190,8 @@ function init_join_output(typ, grp, f, ldata, rdata, left, keepkeys, lkey, rkey,
 
         right_type = eltype(rdata)
         if !isa(typ, Val{:inner})
-            null_right_type = map_params(x->DataValue{x}, eltype(rdata))
+            # null_right_type = map_params(x->DataValue{x}, eltype(rdata))
+            null_right_type = map_params(x->Union{Missing, x}, eltype(rdata))
             rnull = nullrow(null_right_type)
         else
             null_right_type = right_type
@@ -343,18 +345,24 @@ function Base.join(f, left::Dataset, right::Dataset;
         lnulls[lnull_idx] .= true
         lout = if lout isa Columns
             Columns(map(lout.columns) do col
-                        if col isa DataValueArray
-                            col.isna[lnull_idx] .= true
-                        else
-                            DataValueArray(col, lnulls)
-                        end
-                    end)
+                        # if col isa DataValueArray
+                        #     col.isna[lnull_idx] .= true
+                        # else
+                        #     DataValueArray(col, lnulls)
+                        # end
+                v = Vector{Union{Missing,eltype(col)}}(col)
+                v[lnull_idx] .= missing
+                v
+            end)
         else
-            if lout isa DataValueArray
-                lout.isna[lnull_idx] .= true
-            else
-                DataValueArray(lout, lnulls)
-            end
+            v = Vector{Union{Missing, eltype(lout)}}(lout)
+            v[lnull_idx] .= missing
+            v
+            # if lout isa DataValueArray
+            #     lout.isna[lnull_idx] .= true
+            # else
+            #     DataValueArray(lout, lnulls)
+            # end
         end
         data = concat_cols(lout, rout)
     end
@@ -364,18 +372,24 @@ function Base.join(f, left::Dataset, right::Dataset;
         rnulls[rnull_idx] .= true
         rout = if rout isa Columns
             Columns(map(rout.columns) do col
-                        if col isa DataValueArray
-                            col.isna[rnull_idx] .= true
-                        else
-                            DataValueArray(col, rnulls)
-                        end
-                    end)
+                        # if col isa DataValueArray
+                        #     col.isna[rnull_idx] .= true
+                        # else
+                        #     DataValueArray(col, rnulls)
+                        # end
+                v = Vector{Union{Missing,eltype(col)}}(col)
+                v[rnull_idx] .= missing
+                v
+            end)
         else
-            if rout isa DataValueArray
-                rout.isna[rnull_idx] .= true
-            else
-                DataValueArray(rout, rnulls)
-            end
+            v = Vector{Union{Missing,eltype(rout)}}(rout)
+            v[rnull_idx] .= missing
+            v
+            # if rout isa DataValueArray
+            #     rout.isna[rnull_idx] .= true
+            # else
+            #     DataValueArray(rout, rnulls)
+            # end
         end
         data = concat_cols(lout, rout)
     end

--- a/src/join.jl
+++ b/src/join.jl
@@ -343,12 +343,12 @@ function Base.join(f, left::Dataset, right::Dataset;
         lnulls[lnull_idx] .= true
         lout = if lout isa Columns
             Columns(map(lout.columns) do col
-                v = Vector{Union{Missing,eltype(col)}}(col)
+                v = convert(Vector{Union{Missing, eltype(col)}}, col)
                 v[lnull_idx] .= missing
                 v
             end)
         else
-            v = Vector{Union{Missing, eltype(lout)}}(lout)
+            v = convert(Vector{Union{Missing, eltype(lout)}}, lout)
             v[lnull_idx] .= missing
             v
         end
@@ -360,12 +360,12 @@ function Base.join(f, left::Dataset, right::Dataset;
         rnulls[rnull_idx] .= true
         rout = if rout isa Columns
             Columns(map(rout.columns) do col
-                v = Vector{Union{Missing,eltype(col)}}(col)
+                v = convert(Vector{Union{Missing, eltype(col)}}, col)
                 v[rnull_idx] .= missing
                 v
             end)
         else
-            v = Vector{Union{Missing,eltype(rout)}}(rout)
+            v = convert(Vector{Union{Missing, eltype(rout)}}, rout)
             v[rnull_idx] .= missing
             v
         end

--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -189,7 +189,7 @@ end
 
 function (==)(a::NDSparse, b::NDSparse)
     flush!(a); flush!(b)
-    return a.index == b.index && a.data == b.data
+    return isequal(a.index, b.index) && isequal(a.data, b.data)
 end
 
 function Base.isequal(a::NDSparse, b::NDSparse)

--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -271,8 +271,6 @@ function permutedims(t::NDSparse, p::AbstractVector)
 end
 
 # showing
-
-import Base.show
 function show(io::IO, t::NDSparse{T,D}) where {T,D}
     flush!(t)
     if !(values(t) isa Columns)

--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -391,7 +391,7 @@ end
 # aggregation
 
 """
-`aggregate!(f::Function, arr::NDSparse)`
+    aggregate!(f::Function, arr::NDSparse)
 
 Combine adjacent rows with equal indices using the given 2-argument reduction function,
 in place.

--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -189,7 +189,7 @@ end
 
 function (==)(a::NDSparse, b::NDSparse)
     flush!(a); flush!(b)
-    return isequal(a.index, b.index) && isequal(a.data, b.data)
+    return a.index == b.index && a.data == b.data
 end
 
 function Base.isequal(a::NDSparse, b::NDSparse)

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -49,13 +49,14 @@ function unstack(t::D, by = pkeynames(t); variable = :variable, value = :value) 
     S = eltype(colnames(t))
     cols = S.(union(columns(t, variable)))
     T = eltype(columns(t, value))
-    _unstack(D, T, pkeys(tgrp), columns(tgrp, value), cols)
+    _unstack(D, Missing <: T ? nonmissing(T) : T, pkeys(tgrp), columns(tgrp, value), cols)
 end
 
 function _unstack(::Type{D}, ::Type{T}, key, val, cols::AbstractVector{S}) where {D <:Dataset, T, S}
-    dest_val = Columns((Vector{T}(undef, length(val)) for i in cols)...; names=cols)
+    dest_val = Columns((Array{Union{T, Missing}}(undef, length(val)) for i in cols)...; names = cols)
     for (i, el) in enumerate(val)
         for (k, v) in el
+            ismissing(columns(dest_val, S(k))[i]) || error("Repeated values with same label are not allowed")
             columns(dest_val, S(k))[i] = v
         end
     end

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -49,10 +49,10 @@ function unstack(t::D, by = pkeynames(t); variable = :variable, value = :value) 
     S = eltype(colnames(t))
     cols = S.(union(columns(t, variable)))
     T = eltype(columns(t, value))
-    _unstack(D, Missing <: T ? nonmissing(T) : T, pkeys(tgrp), columns(tgrp, value), cols)
+    unstack(D, Missing <: T ? nonmissing(T) : T, pkeys(tgrp), columns(tgrp, value), cols)
 end
 
-function _unstack(::Type{D}, ::Type{T}, key, val, cols::AbstractVector{S}) where {D <:Dataset, T, S}
+function unstack(::Type{D}, ::Type{T}, key, val, cols::AbstractVector{S}) where {D <:Dataset, T, S}
     dest_val = Columns((Array{Union{T, Missing}}(undef, length(val)) for i in cols)...; names = cols)
     for (i, el) in enumerate(val)
         for (k, v) in el

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -49,7 +49,7 @@ function unstack(t::D, by = pkeynames(t); variable = :variable, value = :value) 
     S = eltype(colnames(t))
     cols = S.(union(columns(t, variable)))
     T = eltype(columns(t, value))
-    unstack(D, Missing <: T ? nonmissing(T) : T, pkeys(tgrp), columns(tgrp, value), cols)
+    unstack(D, Base.nonmissingtype(T), pkeys(tgrp), columns(tgrp, value), cols)
 end
 
 function unstack(::Type{D}, ::Type{T}, key, val, cols::AbstractVector{S}) where {D <:Dataset, T, S}

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -29,18 +29,6 @@ function stack(t::D, by = pkeynames(t); select = isa(t, NDSparse) ? valuenames(t
     convert(collectiontype(D), Columns(bycols), Columns(labelcol, valuecol, names = [variable, value]))
 end
 
-function unstack(::Type{D}, ::Type{T}, key, val, cols::AbstractVector{S}) where {D <:Dataset, T, S}
-    dest_val = Columns((DataValues.DataValueArray{T}(length(val)) for i in cols)...; names = cols)
-    for (i, el) in enumerate(val)
-        for j in el
-            k, v = j
-            isna(columns(dest_val, S(k))[i]) || error("Repeated values with same label are not allowed")
-            columns(dest_val, S(k))[i] = v
-        end
-    end
-    convert(collectiontype(D), key, dest_val)
-end
-
 """
     unstack(t, by = pkeynames(t); variable = :variable, value = :value)
 
@@ -61,5 +49,15 @@ function unstack(t::D, by = pkeynames(t); variable = :variable, value = :value) 
     S = eltype(colnames(t))
     cols = S.(union(columns(t, variable)))
     T = eltype(columns(t, value))
-    unstack(D, T isa Type{<:DataValue} ? eltype(T) : T, pkeys(tgrp), columns(tgrp, value), cols)
+    _unstack(D, T, pkeys(tgrp), columns(tgrp, value), cols)
+end
+
+function _unstack(::Type{D}, ::Type{T}, key, val, cols::AbstractVector{S}) where {D <:Dataset, T, S}
+    dest_val = Columns((Vector{T}(undef, length(val)) for i in cols)...; names=cols)
+    for (i, el) in enumerate(val)
+        for (k, v) in el
+            columns(dest_val, S(k))[i] = v
+        end
+    end
+    convert(collectiontype(D), key, dest_val)
 end

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -170,7 +170,6 @@ to `Array{Int}`.
 function dropmissing(t::Dataset, by=colnames(t))
     subtable(_non_missing(t, by)...)
 end
-dropmissing(v::AbstractVector{Union{T,Missing}}) where {T} = Vector{T}(filter(!ismissing, v))
 
 @deprecate dropna dropmissing
 

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -132,50 +132,46 @@ function map(f, t::Dataset; select=nothing, copy=false, kwargs...)
     isa(x, Columns) ? table(x; copy=false, kwargs...) : x
 end
 
-function _nonna(t::Union{Columns, IndexedTable}, by=(colnames(t)...,))
-    indxs = [1:length(t);]
-    if !isa(by, Tuple)
-        by = (by,)
-    end
+function _non_missing(t::Union{Columns, IndexedTable}, sel=(colnames(t)...,))
+    indxs = collect(1:length(t))
+    by = isa(sel, Tuple) ? sel : (sel,)
     bycols = columns(t, by)
     d = ColDict(t)
     for (key, c) in zip(by, bycols)
         x = rows(t, c)
-       #filt_by_col!(!ismissing, x, indxs)
-       #if Missing <: eltype(x)
-       #    y = Array{nonmissing(eltype(x))}(undef, length(x))
-       #    y[indxs] = x[indxs]
-        filt_by_col!(!isna, x, indxs)
-        if isa(x, Array{<:DataValue})
-            y = Array{eltype(eltype(x))}(undef, length(x))
-            y[indxs] = map(get, x[indxs])
-            x = y
-        elseif isa(x, DataValueArray)
-            x = x.values # unsafe unwrap
+        if Missing <: eltype(x)
+            filt_by_col!(!ismissing, x, indxs)
+            y = Vector{nonmissing(eltype(x))}(undef, length(x))
+            y[indxs] = x[indxs]
+            d[key] = y
+        else
+            d[key] = x
         end
-        d[key] = x
     end
     (d[], indxs)
 end
 
 """
-    dropna(t)
-    dropna(t, select)
+    dropmissing(t)
+    dropmissing(t, select)
 
-Drop rows of table `t` which contain NA (`DataValues.DataValue`) values, optionally only 
+Drop rows of table `t` which contain `missing` values, optionally only 
 using the columns in `select`.  
 
-Column types will be converted to non-NA types.  E.g. `Array{DataValue{Int}}` to `Array{Int}`.
+Column types will be converted to non-`Missing` types.  E.g. `Array{Union{Int, Missing}}` 
+to `Array{Int}`.
 
 # Example
 
-    t = table([0.1,0.5,NA,0.7], [2,NA,4,5], [NA,6,NA,7], names=[:t,:x,:y])
-    dropna(t)
-    dropna(t, (:t, :x))
+    t = table([0.1,0.5,missing,0.7], [2,missing,4,5], [missing,6,missing,7], names=[:t,:x,:y])
+    dropmissing(t)
+    dropmissing(t, (:t, :x))
 """
-function dropna(t::Dataset, by=(colnames(t)...,))
-    subtable(_nonna(t, by)...,)
+function dropmissing(t::Dataset, by=colnames(t))
+    subtable(_non_missing(t, by)...)
 end
+
+@deprecate dropna dropmissing
 
 filt_by_col!(f, col, indxs) = filter!(i->f(col[i]), indxs)
 

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -170,6 +170,7 @@ to `Array{Int}`.
 function dropmissing(t::Dataset, by=colnames(t))
     subtable(_non_missing(t, by)...)
 end
+dropmissing(v::AbstractVector{Union{T,Missing}}) where {T} = Vector{T}(filter(!ismissing, v))
 
 @deprecate dropna dropmissing
 

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -41,10 +41,20 @@ end
     getfield(columns(t), which)
 end
 
+"""
+    selectkeys(x::NDSparse, sel)
+
+Return an `NDSparse` with a subset of keys.
+"""
 function selectkeys(x::NDSparse, which; kwargs...)
     ndsparse(rows(keys(x), which), values(x); kwargs...)
 end
 
+"""
+    selectvalues(x::NDSparse, sel)
+
+Return an `NDSparse` with a subset of values
+"""
 function selectvalues(x::NDSparse, which; presorted=true, copy=false, kwargs...)
     ndsparse(keys(x), rows(values(x), which); presorted=presorted, copy=copy, kwargs...)
 end

--- a/src/selection.jl
+++ b/src/selection.jl
@@ -141,7 +141,7 @@ function _non_missing(t::Union{Columns, IndexedTable}, sel=(colnames(t)...,))
         x = rows(t, c)
         if Missing <: eltype(x)
             filt_by_col!(!ismissing, x, indxs)
-            y = Vector{nonmissing(eltype(x))}(undef, length(x))
+            y = Vector{Base.nonmissingtype(eltype(x))}(undef, length(x))
             y[indxs] = x[indxs]
             d[key] = y
         else

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,0 +1,26 @@
+#-----------------------------------------------------------------------# Columns 
+const TableColumns = Columns{T} where {T<:NamedTuple}
+
+Tables.istable(::Type{<:TableColumns}) = true
+Tables.materializer(c::TableColumns) = Columns
+
+Tables.rowaccess(c::TableColumns) = true
+Tables.rows(c::TableColumns) = c
+Tables.schema(c::TableColumns) = Tables.Schema(colnames(c), Tuple(map(eltype, c.columns)))
+
+Tables.columnaccess(c::TableColumns) = true
+Tables.columns(c::TableColumns) = c.columns
+# Tables.schema already defined for NamedTuple of Vectors (c.columns)
+
+#-----------------------------------------------------------------------# IndexedTable/NDSparse
+Tables.istable(::Type{IndexedTable{C}}) where {C<:TableColumns} = true
+Tables.istable(::Type{NDSparse{T,D,C,V}}) where {T,D,C<:TableColumns,V<:TableColumns} = true
+
+Tables.materializer(t::IndexedTable) = table
+Tables.materializer(t::NDSparse) = ndpsarse
+
+for f in [:rowaccess, :rows, :columnaccess, :columns, :schema]
+    @eval Tables.$f(t::Dataset) = Tables.$f(Columns(columns(t)))
+end
+
+

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,6 +1,5 @@
 #-----------------------------------------------------------------------# Columns 
 const TableColumns = Columns{T} where {T<:NamedTuple}
-Columns(x) = Columns(Tables.columntable(x))
 
 Columns(x; kw...) = Columns(Tables.columntable(x); kw...)
 

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,6 +1,8 @@
 #-----------------------------------------------------------------------# Columns 
 const TableColumns = Columns{T} where {T<:NamedTuple}
 
+Columns(x; kw...) = Columns(Tables.columntable(x); kw...)
+
 Tables.istable(::Type{<:TableColumns}) = true
 Tables.materializer(c::TableColumns) = Columns
 
@@ -14,13 +16,15 @@ Tables.columns(c::TableColumns) = c.columns
 
 #-----------------------------------------------------------------------# IndexedTable/NDSparse
 Tables.istable(::Type{IndexedTable{C}}) where {C<:TableColumns} = true
-Tables.istable(::Type{NDSparse{T,D,C,V}}) where {T,D,C<:TableColumns,V<:TableColumns} = true
-
 Tables.materializer(t::IndexedTable) = table
-Tables.materializer(t::NDSparse) = ndpsarse
-
 for f in [:rowaccess, :rows, :columnaccess, :columns, :schema]
-    @eval Tables.$f(t::Dataset) = Tables.$f(Columns(columns(t)))
+    @eval Tables.$f(t::IndexedTable) = Tables.$f(Columns(columns(t)))
 end
+
+#-----------------------------------------------------------------------# NDSparse
+# Tables.istable(::Type{NDSparse{T,D,C,V}}) where {T,D,C<:TableColumns,V<:TableColumns} = true
+# Tables.materializer(t::NDSparse) = ndpsarse
+
+
 
 

--- a/src/tabletraits.jl
+++ b/src/tabletraits.jl
@@ -4,16 +4,6 @@ function IteratorInterfaceExtensions.getiterator(source::NDSparse)
     return rows(source)
 end
 
-function _array_factory(t,rows)
-    if isa(t, TypeVar)
-        return Array{Any}(undef, rows)
-    elseif t <: DataValue
-        return DataValueArray{eltype(t)}(rows)
-    else
-        return Array{t}(undef, rows)
-    end
-end
-
 function ndsparse(x; idxcols=nothing, datacols=nothing, copy=false, kwargs...)
     if isiterable(x)
         source_data = collect_columns(getiterator(x))

--- a/src/tabletraits.jl
+++ b/src/tabletraits.jl
@@ -52,10 +52,10 @@ function table(rows::AbstractArray{T}; copy=false, kwargs...) where {T<:Union{Tu
     table(collect_columns(rows); copy=false, kwargs...)
 end
 
-function table(iter; copy=false, kwargs...)
+function table(iter; copy=false, kw...)
     if TableTraits.isiterable(iter)
-        table(collect_columns(getiterator(iter)); copy=false, kwargs...)
+        table(collect_columns(getiterator(iter)); copy=copy, kw...)
     else
-        throw(ArgumentError("iter cannot be turned into a IndexedTable."))
+        table(Tables.columntable(iter); copy=copy, kw...)
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,3 @@
-import Base: tuple_type_cons, tuple_type_head, tuple_type_tail, in, ==, isless, convert,
-             length, eltype, show
-
 (T::Type{<:StringArray})(::typeof(undef), args...) = T(args...)
 
 fastmap(f, xs...) = map(f, xs...)
@@ -332,7 +329,7 @@ end
 compact_mem(x) = x
 compact_mem(x::StringArray{String}) = convert(StringArray{WeakRefString{UInt8}}, x)
 
-#nonmissing(::Type{Union{Missing, T}}) where T = T
+nonmissing(::Type{Union{Missing, T}}) where T = T
 
 function getsubfields(n::NamedTuple, fields)
     fns = fieldnames(typeof(n))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -161,7 +161,7 @@ function namedtuple(fields...)
 end
 
 """
-`arrayof(T)`
+    arrayof(T)
 
 Returns the type of `Columns` or `Vector` suitable to store
 values of type T. Nested tuples beget nested Columns.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -329,8 +329,6 @@ end
 compact_mem(x) = x
 compact_mem(x::StringArray{String}) = convert(StringArray{WeakRefString{UInt8}}, x)
 
-nonmissing(::Type{Union{Missing, T}}) where T = T
-
 function getsubfields(n::NamedTuple, fields)
     fns = fieldnames(typeof(n))
     NamedTuple{(fns[fields]...,)}(n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,8 @@
-using Test, IndexedTables, OnlineStats, DataValues, WeakRefStrings
+using Test, IndexedTables, OnlineStats, DataValues, WeakRefStrings, Tables
 import DataValues: NA
 
-@testset "IndexedTables" begin
-
-include("test_core.jl")
-include("test_utils.jl")
-include("test_tabletraits.jl")
-include("test_collect.jl")
-
-end
+include("test_tables.jl")
+# include("test_core.jl")
+# include("test_utils.jl")
+# include("test_tabletraits.jl")
+# include("test_collect.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test, IndexedTables, OnlineStats, DataValues, WeakRefStrings, Tables
-import DataValues: NA
+# import DataValues: NA
 
 include("test_tables.jl")
 include("test_core.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,10 @@ using Test, IndexedTables, OnlineStats, WeakRefStrings, Tables, Random, Dates,
 using IndexedTables: excludecols, sortpermby, primaryperm, best_perm_estimate, hascolumns,
     collect_columns_flattened
 
+if VERSION < v"1.0-"
+    select = IndexedTables.select
+end
+
 include("test_tables.jl")
 include("test_missing.jl")
 include("test_join.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test, IndexedTables, OnlineStats, WeakRefStrings, Tables
 
 include("test_tables.jl")
+include("test_missing.jl")
 include("test_core.jl")
 include("test_utils.jl")
 include("test_tabletraits.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
 using Test, IndexedTables, OnlineStats, WeakRefStrings, Tables
 
+
 include("test_tables.jl")
 include("test_missing.jl")
+include("test_join.jl")
 include("test_core.jl")
 include("test_utils.jl")
 include("test_tabletraits.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
-using Test, IndexedTables, OnlineStats, DataValues, WeakRefStrings, Tables
-# import DataValues: NA
+using Test, IndexedTables, OnlineStats, WeakRefStrings, Tables
 
 include("test_tables.jl")
 include("test_core.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Test, IndexedTables, OnlineStats, DataValues, WeakRefStrings, Tables
 import DataValues: NA
 
 include("test_tables.jl")
-# include("test_core.jl")
-# include("test_utils.jl")
-# include("test_tabletraits.jl")
-# include("test_collect.jl")
+include("test_core.jl")
+include("test_utils.jl")
+include("test_tabletraits.jl")
+include("test_collect.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
-using Test, IndexedTables, OnlineStats, WeakRefStrings, Tables
+using Test, IndexedTables, OnlineStats, WeakRefStrings, Tables, Random, Dates, 
+    PooledArrays, SparseArrays, WeakRefStrings, LinearAlgebra, Statistics,
+    TableTraits, IteratorInterfaceExtensions, Serialization
 
+using IndexedTables: excludecols, sortpermby, primaryperm, best_perm_estimate, hascolumns,
+    collect_columns_flattened
 
 include("test_tables.jl")
 include("test_missing.jl")

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -124,8 +124,8 @@ end
     @test collect_columns(v) == Columns(Columns((a = Int[],))=>Columns((b = String[],)))
     @test eltype(collect_columns(v)) == Pair{NamedTuple{(:a,), Tuple{Int}}, NamedTuple{(:b,), Tuple{String}}}
 
-    # t = table(collect_columns((b = 1,) => (a = i,) for i in (2, DataValue{Int}(), 3)))
-    # @test t == table((b = [1,1,1], a = [2, DataValue{Int}(), 3]), pkey = :b)
+    t = table(collect_columns((b = 1,) => (a = i,) for i in (2, missing, 3)))
+    @test t == table((b = [1,1,1], a = [2, missing, 3]), pkey = :b)
 end
 
 @testset "issubtype" begin

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -125,7 +125,7 @@ end
     @test eltype(collect_columns(v)) == Pair{NamedTuple{(:a,), Tuple{Int}}, NamedTuple{(:b,), Tuple{String}}}
 
     t = table(collect_columns((b = 1,) => (a = i,) for i in (2, missing, 3)))
-    @test t == table((b = [1,1,1], a = [2, missing, 3]), pkey = :b)
+    @test isequal(t, table((b = [1,1,1], a = [2, missing, 3]), pkey = :b))
 end
 
 @testset "issubtype" begin

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -95,9 +95,9 @@ end
     tuple_itr = (exp(i) for i in itr)
     @test collect_columns(tuple_itr) == Float64[]
 
-    t = collect_columns((a = i,) for i in (1, DataValue{Int}(), 3))
-    @test columns(t, 1) isa DataValueArray
-    @test isequal(columns(t, 1), DataValueArray([1, DataValue{Int}(), 3]))
+    # t = collect_columns((a = i,) for i in (1, DataValue{Int}(), 3))
+    # @test columns(t, 1) isa DataValueArray
+    # @test isequal(columns(t, 1), DataValueArray([1, DataValue{Int}(), 3]))
 end
 
 @testset "collectpairs" begin
@@ -126,8 +126,8 @@ end
     @test collect_columns(v) == Columns(Columns((a = Int[],))=>Columns((b = String[],)))
     @test eltype(collect_columns(v)) == Pair{NamedTuple{(:a,), Tuple{Int}}, NamedTuple{(:b,), Tuple{String}}}
 
-    t = table(collect_columns((b = 1,) => (a = i,) for i in (2, DataValue{Int}(), 3)))
-    @test t == table((b = [1,1,1], a = [2, DataValue{Int}(), 3]), pkey = :b)
+    # t = table(collect_columns((b = 1,) => (a = i,) for i in (2, DataValue{Int}(), 3)))
+    # @test t == table((b = [1,1,1], a = [2, DataValue{Int}(), 3]), pkey = :b)
 end
 
 @testset "issubtype" begin

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -1,5 +1,3 @@
-using IndexedTables: collect_columns_flattened
-
 @testset "collectnamedtuples" begin
     v = [(a = 1, b = 2), (a = 1, b = 3)]
     @test collect_columns(v) == Columns((a = Int[1, 1], b = Int[2, 3]))
@@ -95,9 +93,9 @@ end
     tuple_itr = (exp(i) for i in itr)
     @test collect_columns(tuple_itr) == Float64[]
 
-    # t = collect_columns((a = i,) for i in (1, DataValue{Int}(), 3))
-    # @test columns(t, 1) isa DataValueArray
-    # @test isequal(columns(t, 1), DataValueArray([1, DataValue{Int}(), 3]))
+    t = collect_columns((a = i,) for i in (1, missing, 3))
+    @test columns(t, 1) isa Vector{Union{Missing, Int}}
+    @test isequal(columns(t, 1), [1, missing, 3])
 end
 
 @testset "collectpairs" begin

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -641,8 +641,8 @@ end
     l = table([1, 1, 2, 2], [1, 2, 1, 2], [1, 2, 3, 4], names=[:a, :b, :c], pkey=(:a, :b))
     r = table([0, 1, 1, 3], [1, 1, 2, 2], [1, 2, 3, 4], names=[:a, :b, :d], pkey=(:a, :b))
     @test join(l, r) == table([1, 1], [1, 2], [1, 2], [2, 3], names=Symbol[:a, :b, :c, :d])
-    @test isequal(join(l, r, how=:left), table([1, 1, 2, 2], [1, 2, 1, 2], [1, 2, 3, 4], DataValueArray([2, 3, NA, NA]), names=Symbol[:a, :b, :c, :d]))
-    @test isequal(join(l, r, how=:outer), table([0, 1, 1, 2, 2, 3], [1, 1, 2, 1, 2, 2], DataValueArray([NA, 1, 2, 3, 4, NA]), DataValueArray([1, 2, 3, NA, NA, 4]), names=Symbol[:a, :b, :c, :d]))
+    # @test isequal(join(l, r, how=:left), table([1, 1, 2, 2], [1, 2, 1, 2], [1, 2, 3, 4], DataValueArray([2, 3, NA, NA]), names=Symbol[:a, :b, :c, :d]))
+    # @test isequal(join(l, r, how=:outer), table([0, 1, 1, 2, 2, 3], [1, 1, 2, 1, 2, 2], DataValueArray([NA, 1, 2, 3, 4, NA]), DataValueArray([1, 2, 3, NA, NA, 4]), names=Symbol[:a, :b, :c, :d]))
     a = table([1],[2], names=[:x,:y])
     b = table([1],[3], names=[:a,:b])
     @test join(a, b, lkey=:x,rkey=:a) == table([1],[2],[3], names=[:x,:y,:b]) # issue JuliaDB.jl#105
@@ -651,11 +651,11 @@ end
     l1 = table([1, 2, 2, 3], [1, 2, 3, 4], names=[:x, :y])
     r1 = table([2, 2, 3, 3], [5, 6, 7, 8], names=[:x, :z])
     @test join(l1, r1, lkey=:x, rkey=:x) == table([2, 2, 2, 2, 3, 3], [2, 2, 3, 3, 4, 4], [5, 6, 5, 6, 7, 8], names=Symbol[:x, :y, :z])
-    @test isequal(join(l, r, lkey=:a, rkey=:a, lselect=:b, rselect=:d, how=:outer), table([0, 1, 1, 1, 1, 2, 2, 3], DataValueArray([NA, 1, 1, 2, 2, 1, 2, NA]), DataValueArray([1, 2, 3, 2, 3, NA, NA, 4]), names=Symbol[:a, :b, :d]))
+    # @test isequal(join(l, r, lkey=:a, rkey=:a, lselect=:b, rselect=:d, how=:outer), table([0, 1, 1, 1, 1, 2, 2, 3], DataValueArray([NA, 1, 1, 2, 2, 1, 2, NA]), DataValueArray([1, 2, 3, 2, 3, NA, NA, 4]), names=Symbol[:a, :b, :d]))
 
 
     t = table(["a","b","c","a"], [1,2,3,4]); t1 = table(["a","b"], [1,2])
-    @test isequal(leftjoin(t,t1,lkey=1,rkey=1), table(["a","a","b","c"], [1,4,2,3], [1,1,2,NA]))
+    # @test isequal(leftjoin(t,t1,lkey=1,rkey=1), table(["a","a","b","c"], [1,4,2,3], [1,1,2,NA]))
 
     t1 = table([1,2,3,4], [5,6,7,8], pkey=[1])
     t2 = table([0,3,4,5], [5,6,7,8], pkey=[1])
@@ -679,35 +679,35 @@ end
     @test naturaljoin(a, c) == NDSparse([12,32], [52,34], Columns([11,150], [0,1], [2,3]))
     @test naturaljoin(c, a) == NDSparse([12,32], [52,34], Columns([0,1], [2,3], [11,150]))
 
-    @test isequal(
-              leftjoin(t1, t2, lselect=2, rselect=2),
-              table([1,2,3,4], [5,6,7,8], [NA, NA, 6, 7]))
+    # @test isequal(
+    #           leftjoin(t1, t2, lselect=2, rselect=2),
+    #           table([1,2,3,4], [5,6,7,8], [NA, NA, 6, 7]))
 
     # null instead of missing row
-    @test isequal(leftjoin(+, t1, t2, lselect=2, rselect=2), table([1,2,3,4], [NA, NA, 13, 15]))
+    # @test isequal(leftjoin(+, t1, t2, lselect=2, rselect=2), table([1,2,3,4], [NA, NA, 13, 15]))
 
-    @test isequal(leftjoin(t1, t2), table([1,2,3,4], [5,6,7,8], [NA, NA, 6,7]))
-    @test isequal(leftjoin(+, t1, t3, lselect=2, rselect=2), table([1,2,3,4,4],[NA,NA,13,15,16]))
-    @test isequal(leftjoin(+, t3, t4, lselect=2, rselect=2), table([0,3,4,4,4,4], [NA, 12, 14,15,15,16]))
+    # @test isequal(leftjoin(t1, t2), table([1,2,3,4], [5,6,7,8], [NA, NA, 6,7]))
+    # @test isequal(leftjoin(+, t1, t3, lselect=2, rselect=2), table([1,2,3,4,4],[NA,NA,13,15,16]))
+    # @test isequal(leftjoin(+, t3, t4, lselect=2, rselect=2), table([0,3,4,4,4,4], [NA, 12, 14,15,15,16]))
 
-    @test isequal(leftjoin(NDSparse([1,1,1,2], [2,3,4,4], [5,6,7,8]),
-                   NDSparse([1,1,3],   [2,4,4],   [9,10,12])),
-                  NDSparse([1,1,1,2], [2,3,4,4], Columns([5, 6, 7, 8], [9, NA, 10, NA])))
+    # @test isequal(leftjoin(NDSparse([1,1,1,2], [2,3,4,4], [5,6,7,8]),
+    #                NDSparse([1,1,3],   [2,4,4],   [9,10,12])),
+    #               NDSparse([1,1,1,2], [2,3,4,4], Columns([5, 6, 7, 8], [9, NA, 10, NA])))
 
-    @test isequal(
-                  leftjoin(NDSparse([1,1,1,2], [2,3,4,4], [5,6,7,8]),
-                   NDSparse([1,1,2],   [2,4,4],   [9,10,12])),
-                  NDSparse([1,1,1,2], [2,3,4,4], Columns([5, 6, 7, 8], [9, NA, 10, 12])))
+    # @test isequal(
+    #               leftjoin(NDSparse([1,1,1,2], [2,3,4,4], [5,6,7,8]),
+    #                NDSparse([1,1,2],   [2,4,4],   [9,10,12])),
+    #               NDSparse([1,1,1,2], [2,3,4,4], Columns([5, 6, 7, 8], [9, NA, 10, 12])))
 
 
-    @test isequal(outerjoin(t1, t2, lselect=2, rselect=2), table([0,1,2,3,4,5], [NA, 5,6,7,8,NA], [5,NA,NA,6,7,8]))
+    # @test isequal(outerjoin(t1, t2, lselect=2, rselect=2), table([0,1,2,3,4,5], [NA, 5,6,7,8,NA], [5,NA,NA,6,7,8]))
 
     #showl instead of missing row
-    @test isequal(outerjoin(+, t1, t2, lselect=2, rselect=2), table([0,1,2,3,4,5], [NA, NA, NA, 13, 15, NA]))
+    # @test isequal(outerjoin(+, t1, t2, lselect=2, rselect=2), table([0,1,2,3,4,5], [NA, NA, NA, 13, 15, NA]))
 
-    @test isequal(outerjoin(t1, t2), table([0,1,2,3,4,5], [NA, 5,6,7,8,NA], [5,NA,NA,6,7,8]))
-    @test isequal(outerjoin(+, t1, t3, lselect=2, rselect=2), table([0,1,2,3,4,4],[NA,NA,NA,13,15,16]))
-    @test isequal(outerjoin(+, t3, t4, lselect=2, rselect=2), table([0,1,3,4,4,4,4], [NA, NA, 12,14,15,15,16]))
+    # @test isequal(outerjoin(t1, t2), table([0,1,2,3,4,5], [NA, 5,6,7,8,NA], [5,NA,NA,6,7,8]))
+    # @test isequal(outerjoin(+, t1, t3, lselect=2, rselect=2), table([0,1,2,3,4,4],[NA,NA,NA,13,15,16]))
+    # @test isequal(outerjoin(+, t3, t4, lselect=2, rselect=2), table([0,1,3,4,4,4,4], [NA, NA, 12,14,15,15,16]))
 
 @testset "groupjoin" begin
     l = table([1, 1, 1, 2], [1, 2, 2, 1], [1, 2, 3, 4], names=[:a, :b, :c], pkey=(:a, :b))

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -797,11 +797,11 @@ end
     @test hascolumns(t, r"x|z")
 end
 
-    t = table([0.1, 0.5, NA, 0.7], [2, NA, 4, 5], [NA, 6, NA, 7], names=[:t, :x, :y])
-    @test dropna(t) == table([0.7], [5], [7], names=Symbol[:t, :x, :y])
-    @test isequal(dropna(t, :y), table([0.5, 0.7], [NA, 5], [6, 7], names=Symbol[:t, :x, :y]))
-    t1 = dropna(t, (:t, :x))
-    @test typeof(column(dropna(t, :x), :x)) == Array{Int,1}
+    # t = table([0.1, 0.5, NA, 0.7], [2, NA, 4, 5], [NA, 6, NA, 7], names=[:t, :x, :y])
+    # @test dropna(t) == table([0.7], [5], [7], names=Symbol[:t, :x, :y])
+    # @test isequal(dropna(t, :y), table([0.5, 0.7], [NA, 5], [6, 7], names=Symbol[:t, :x, :y]))
+    # t1 = dropna(t, (:t, :x))
+    # @test typeof(column(dropna(t, :x), :x)) == Array{Int,1}
 
 @testset "filter" begin
     t = table(["a", "b", "c"], [0.01, 0.05, 0.07], [2, 1, 0], names=[:n, :t, :x])

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -759,6 +759,8 @@ end
     @test select(t, Between(:x, :z)) == select(t, (:x, :y, :z))
     @test select(t, i -> i == :y) == select(t, (:y,))
     @test select(t, r"x|z") == select(t, (:x, :z))
+    @test select(t, Int) == select(t, (:x, :z))
+    @test select(t, String) == select(t, (:y,))
 
     @test rows(t, Keys()) == rows(t, (:x,))
     @test rows(t, (Keys(), :y)) == rows(t, ((:x,), :y))

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -637,11 +637,18 @@ end
     @test map(t -> (1,2), table(Int[])) == table(Int[], Int[])
 end
 
+@testset "Original Join Testset" begin
     l = table([1, 1, 2, 2], [1, 2, 1, 2], [1, 2, 3, 4], names=[:a, :b, :c], pkey=(:a, :b))
     r = table([0, 1, 1, 3], [1, 1, 2, 2], [1, 2, 3, 4], names=[:a, :b, :d], pkey=(:a, :b))
     @test join(l, r) == table([1, 1], [1, 2], [1, 2], [2, 3], names=Symbol[:a, :b, :c, :d])
-    @test join(l, r, how=:left) == table([1, 1, 2, 2], [1, 2, 1, 2], [1, 2, 3, 4], [2, 3, missing, missing], names=Symbol[:a, :b, :c, :d])
-    @test isequal(join(l, r, how=:outer), table([0, 1, 1, 2, 2, 3], [1, 1, 2, 1, 2, 2], [missing, 1, 2, 3, 4, missing], [1, 2, 3, missing, missing, 4], names=Symbol[:a, :b, :c, :d]))
+    @test isequal(
+        join(l, r, how=:left),
+        table((a=[1, 1, 2, 2], b=[1, 2, 1, 2], c=[1, 2, 3, 4], d=[2, 3, missing, missing]))
+    )
+    @test isequal(
+        join(l, r, how=:outer), 
+        table((a=[0, 1, 1, 2, 2, 3], b=[1, 1, 2, 1, 2, 2], c=[missing, 1, 2, 3, 4, missing], d=[1, 2, 3, missing, missing, 4]))
+    )
     a = table([1],[2], names=[:x,:y])
     b = table([1],[3], names=[:a,:b])
     @test join(a, b, lkey=:x,rkey=:a) == table([1],[2],[3], names=[:x,:y,:b]) # issue JuliaDB.jl#105
@@ -654,7 +661,7 @@ end
 
 
     t = table(["a","b","c","a"], [1,2,3,4]); t1 = table(["a","b"], [1,2])
-    @test leftjoin(t,t1,lkey=1,rkey=1) == table(["a","a","b","c"], [1,4,2,3], [1,1,2,missing])
+    @test isequal(leftjoin(t,t1,lkey=1,rkey=1), table(["a","a","b","c"], [1,4,2,3], [1,1,2,missing]))
 
     t1 = table([1,2,3,4], [5,6,7,8], pkey=[1])
     t2 = table([0,3,4,5], [5,6,7,8], pkey=[1])
@@ -684,7 +691,10 @@ end
     )
 
     # null instead of missing row
-    @test isequal(leftjoin(+, t1, t2, lselect=2, rselect=2), table([1,2,3,4], [missing, missing, 13, 15]))
+    @test isequal(
+        leftjoin(+, t1, t2, lselect=2, rselect=2), 
+        table([1,2,3,4], [missing, missing, 13, 15])
+    )
 
     @test isequal(leftjoin(t1, t2), table([1,2,3,4], [5,6,7,8], [missing, missing, 6,7]))
     @test isequal(leftjoin(+, t1, t3, lselect=2, rselect=2), table([1,2,3,4,4],[missing,missing,13,15,16]))
@@ -708,7 +718,7 @@ end
     @test isequal(outerjoin(t1, t2), table([0,1,2,3,4,5], [missing, 5,6,7,8,missing], [5,missing,missing,6,7,8]))
     @test isequal(outerjoin(+, t1, t3, lselect=2, rselect=2), table([0,1,2,3,4,4],[missing,missing,missing,13,15,16]))
     @test isequal(outerjoin(+, t3, t4, lselect=2, rselect=2), table([0,1,3,4,4,4,4], [missing, missing, 12,14,15,15,16]))
-
+end
 @testset "groupjoin" begin
     l = table([1, 1, 1, 2], [1, 2, 2, 1], [1, 2, 3, 4], names=[:a, :b, :c], pkey=(:a, :b))
     r = table([0, 1, 1, 2], [1, 2, 2, 1], [1, 2, 3, 4], names=[:a, :b, :d], pkey=(:a, :b))
@@ -798,13 +808,12 @@ end
     @test hascolumns(t, i -> i == :y)
     @test hascolumns(t, r"x|z")
 end
-
+@testset "dropmissing" begin
     t = table([0.1, 0.5, missing, 0.7], [2, missing, 4, 5], [missing, 6, missing, 7], names=[:t, :x, :y])
     @test dropmissing(t) == table([0.7], [5], [7], names=Symbol[:t, :x, :y])
     @test isequal(dropmissing(t, :y), table([0.5, 0.7], [missing, 5], [6, 7], names=Symbol[:t, :x, :y]))
-    t1 = dropmissing(t, (:t, :x))
     @test typeof(column(dropmissing(t, :x), :x)) == Array{Int,1}
-
+end
 @testset "filter" begin
     t = table(["a", "b", "c"], [0.01, 0.05, 0.07], [2, 1, 0], names=[:n, :t, :x])
     @test filter((p->p.x / p.t < 100), t) == table(["b", "c"], [0.05, 0.07], [1, 0], names=Symbol[:n, :t, :x])

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -1,5 +1,4 @@
-using Test, Random, Dates, IndexedTables, PooledArrays, SparseArrays, WeakRefStrings, LinearAlgebra, Statistics
-import IndexedTables: update!, pkeynames, pkeys, excludecols, sortpermby, primaryperm, best_perm_estimate, hascolumns, select
+
 
     c = Columns([1,1,1,2,2], [1,2,4,3,5])
     d = Columns([1,1,2,2,2], [1,3,1,4,5])
@@ -147,7 +146,7 @@ end
     @test collect(Base.pairs(a)) == [(1,1)=>10, (2,2)=>9, (2,3)=>8, (2,4)=>7]
     @test first(Base.pairs(a[:, 3])) == ((2,)=>8)
 
-    update!(x->x+10, a, 2, :)
+    IndexedTables.update!(x->x+10, a, 2, :)
     @test a == NDSparse([1,2,2,2], [1,2,3,4], [10,19,18,17])
 
     a[2,2:3] = 77

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -640,8 +640,8 @@ end
     l = table([1, 1, 2, 2], [1, 2, 1, 2], [1, 2, 3, 4], names=[:a, :b, :c], pkey=(:a, :b))
     r = table([0, 1, 1, 3], [1, 1, 2, 2], [1, 2, 3, 4], names=[:a, :b, :d], pkey=(:a, :b))
     @test join(l, r) == table([1, 1], [1, 2], [1, 2], [2, 3], names=Symbol[:a, :b, :c, :d])
-    # @test isequal(join(l, r, how=:left), table([1, 1, 2, 2], [1, 2, 1, 2], [1, 2, 3, 4], DataValueArray([2, 3, NA, NA]), names=Symbol[:a, :b, :c, :d]))
-    # @test isequal(join(l, r, how=:outer), table([0, 1, 1, 2, 2, 3], [1, 1, 2, 1, 2, 2], DataValueArray([NA, 1, 2, 3, 4, NA]), DataValueArray([1, 2, 3, NA, NA, 4]), names=Symbol[:a, :b, :c, :d]))
+    @test join(l, r, how=:left) == table([1, 1, 2, 2], [1, 2, 1, 2], [1, 2, 3, 4], [2, 3, missing, missing], names=Symbol[:a, :b, :c, :d])
+    @test isequal(join(l, r, how=:outer), table([0, 1, 1, 2, 2, 3], [1, 1, 2, 1, 2, 2], [missing, 1, 2, 3, 4, missing], [1, 2, 3, missing, missing, 4], names=Symbol[:a, :b, :c, :d]))
     a = table([1],[2], names=[:x,:y])
     b = table([1],[3], names=[:a,:b])
     @test join(a, b, lkey=:x,rkey=:a) == table([1],[2],[3], names=[:x,:y,:b]) # issue JuliaDB.jl#105
@@ -650,11 +650,11 @@ end
     l1 = table([1, 2, 2, 3], [1, 2, 3, 4], names=[:x, :y])
     r1 = table([2, 2, 3, 3], [5, 6, 7, 8], names=[:x, :z])
     @test join(l1, r1, lkey=:x, rkey=:x) == table([2, 2, 2, 2, 3, 3], [2, 2, 3, 3, 4, 4], [5, 6, 5, 6, 7, 8], names=Symbol[:x, :y, :z])
-    # @test isequal(join(l, r, lkey=:a, rkey=:a, lselect=:b, rselect=:d, how=:outer), table([0, 1, 1, 1, 1, 2, 2, 3], DataValueArray([NA, 1, 1, 2, 2, 1, 2, NA]), DataValueArray([1, 2, 3, 2, 3, NA, NA, 4]), names=Symbol[:a, :b, :d]))
+    @test isequal(join(l, r, lkey=:a, rkey=:a, lselect=:b, rselect=:d, how=:outer), table([0, 1, 1, 1, 1, 2, 2, 3], [missing, 1, 1, 2, 2, 1, 2, missing], [1, 2, 3, 2, 3, missing, missing, 4], names=Symbol[:a, :b, :d]))
 
 
     t = table(["a","b","c","a"], [1,2,3,4]); t1 = table(["a","b"], [1,2])
-    # @test isequal(leftjoin(t,t1,lkey=1,rkey=1), table(["a","a","b","c"], [1,4,2,3], [1,1,2,NA]))
+    @test leftjoin(t,t1,lkey=1,rkey=1) == table(["a","a","b","c"], [1,4,2,3], [1,1,2,missing])
 
     t1 = table([1,2,3,4], [5,6,7,8], pkey=[1])
     t2 = table([0,3,4,5], [5,6,7,8], pkey=[1])
@@ -678,35 +678,36 @@ end
     @test naturaljoin(a, c) == NDSparse([12,32], [52,34], Columns([11,150], [0,1], [2,3]))
     @test naturaljoin(c, a) == NDSparse([12,32], [52,34], Columns([0,1], [2,3], [11,150]))
 
-    # @test isequal(
-    #           leftjoin(t1, t2, lselect=2, rselect=2),
-    #           table([1,2,3,4], [5,6,7,8], [NA, NA, 6, 7]))
+    @test isequal(
+        leftjoin(t1, t2, lselect=2, rselect=2),
+        table([1,2,3,4], [5,6,7,8], [missing, missing, 6, 7])
+    )
 
     # null instead of missing row
-    # @test isequal(leftjoin(+, t1, t2, lselect=2, rselect=2), table([1,2,3,4], [NA, NA, 13, 15]))
+    @test isequal(leftjoin(+, t1, t2, lselect=2, rselect=2), table([1,2,3,4], [missing, missing, 13, 15]))
 
-    # @test isequal(leftjoin(t1, t2), table([1,2,3,4], [5,6,7,8], [NA, NA, 6,7]))
-    # @test isequal(leftjoin(+, t1, t3, lselect=2, rselect=2), table([1,2,3,4,4],[NA,NA,13,15,16]))
-    # @test isequal(leftjoin(+, t3, t4, lselect=2, rselect=2), table([0,3,4,4,4,4], [NA, 12, 14,15,15,16]))
+    @test isequal(leftjoin(t1, t2), table([1,2,3,4], [5,6,7,8], [missing, missing, 6,7]))
+    @test isequal(leftjoin(+, t1, t3, lselect=2, rselect=2), table([1,2,3,4,4],[missing,missing,13,15,16]))
+    @test isequal(leftjoin(+, t3, t4, lselect=2, rselect=2), table([0,3,4,4,4,4], [missing, 12, 14,15,15,16]))
 
-    # @test isequal(leftjoin(NDSparse([1,1,1,2], [2,3,4,4], [5,6,7,8]),
-    #                NDSparse([1,1,3],   [2,4,4],   [9,10,12])),
-    #               NDSparse([1,1,1,2], [2,3,4,4], Columns([5, 6, 7, 8], [9, NA, 10, NA])))
+    @test isequal(leftjoin(NDSparse([1,1,1,2], [2,3,4,4], [5,6,7,8]),
+                   NDSparse([1,1,3],   [2,4,4],   [9,10,12])),
+                  NDSparse([1,1,1,2], [2,3,4,4], Columns([5, 6, 7, 8], [9, missing, 10, missing])))
 
-    # @test isequal(
-    #               leftjoin(NDSparse([1,1,1,2], [2,3,4,4], [5,6,7,8]),
-    #                NDSparse([1,1,2],   [2,4,4],   [9,10,12])),
-    #               NDSparse([1,1,1,2], [2,3,4,4], Columns([5, 6, 7, 8], [9, NA, 10, 12])))
+    @test isequal(
+                  leftjoin(NDSparse([1,1,1,2], [2,3,4,4], [5,6,7,8]),
+                   NDSparse([1,1,2],   [2,4,4],   [9,10,12])),
+                  NDSparse([1,1,1,2], [2,3,4,4], Columns([5, 6, 7, 8], [9, missing, 10, 12])))
 
 
-    # @test isequal(outerjoin(t1, t2, lselect=2, rselect=2), table([0,1,2,3,4,5], [NA, 5,6,7,8,NA], [5,NA,NA,6,7,8]))
+    @test isequal(outerjoin(t1, t2, lselect=2, rselect=2), table([0,1,2,3,4,5], [missing, 5,6,7,8,missing], [5,missing,missing,6,7,8]))
 
     #showl instead of missing row
-    # @test isequal(outerjoin(+, t1, t2, lselect=2, rselect=2), table([0,1,2,3,4,5], [NA, NA, NA, 13, 15, NA]))
+    @test isequal(outerjoin(+, t1, t2, lselect=2, rselect=2), table([0,1,2,3,4,5], [missing, missing, missing, 13, 15, missing]))
 
-    # @test isequal(outerjoin(t1, t2), table([0,1,2,3,4,5], [NA, 5,6,7,8,NA], [5,NA,NA,6,7,8]))
-    # @test isequal(outerjoin(+, t1, t3, lselect=2, rselect=2), table([0,1,2,3,4,4],[NA,NA,NA,13,15,16]))
-    # @test isequal(outerjoin(+, t3, t4, lselect=2, rselect=2), table([0,1,3,4,4,4,4], [NA, NA, 12,14,15,15,16]))
+    @test isequal(outerjoin(t1, t2), table([0,1,2,3,4,5], [missing, 5,6,7,8,missing], [5,missing,missing,6,7,8]))
+    @test isequal(outerjoin(+, t1, t3, lselect=2, rselect=2), table([0,1,2,3,4,4],[missing,missing,missing,13,15,16]))
+    @test isequal(outerjoin(+, t3, t4, lselect=2, rselect=2), table([0,1,3,4,4,4,4], [missing, missing, 12,14,15,15,16]))
 
 @testset "groupjoin" begin
     l = table([1, 1, 1, 2], [1, 2, 2, 1], [1, 2, 3, 4], names=[:a, :b, :c], pkey=(:a, :b))

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -797,11 +797,11 @@ end
     @test hascolumns(t, r"x|z")
 end
 
-    # t = table([0.1, 0.5, NA, 0.7], [2, NA, 4, 5], [NA, 6, NA, 7], names=[:t, :x, :y])
-    # @test dropna(t) == table([0.7], [5], [7], names=Symbol[:t, :x, :y])
-    # @test isequal(dropna(t, :y), table([0.5, 0.7], [NA, 5], [6, 7], names=Symbol[:t, :x, :y]))
-    # t1 = dropna(t, (:t, :x))
-    # @test typeof(column(dropna(t, :x), :x)) == Array{Int,1}
+    t = table([0.1, 0.5, missing, 0.7], [2, missing, 4, 5], [missing, 6, missing, 7], names=[:t, :x, :y])
+    @test dropmissing(t) == table([0.7], [5], [7], names=Symbol[:t, :x, :y])
+    @test isequal(dropmissing(t, :y), table([0.5, 0.7], [missing, 5], [6, 7], names=Symbol[:t, :x, :y]))
+    t1 = dropmissing(t, (:t, :x))
+    @test typeof(column(dropmissing(t, :x), :x)) == Array{Int,1}
 
 @testset "filter" begin
     t = table(["a", "b", "c"], [0.01, 0.05, 0.07], [2, 1, 0], names=[:n, :t, :x])

--- a/test/test_join.jl
+++ b/test/test_join.jl
@@ -7,13 +7,13 @@
 
     @testset "how = :inner" begin
         t_inner = table((x = 1:2:9, y = y[1:2:9], z = z[1:5]), pkey = :x)
-        @test join(t, t2; how=:inner) == t_inner
+        @test isequal(join(t, t2; how=:inner), t_inner)
     end
     @testset "how = :left" begin
         z_left = Union{Float64,Missing}[missing for i in 1:10]
         z_left[1:2:9] = z[1:5]
         t_left = table((x = 1:10, y = y, z = z_left))
-        @test join(t, t2; how=:left)  == t_left
+        @test isequal(join(t, t2; how=:left), t_left)
     end
     @testset "how = :outer" begin 
         x_outer = union(1:10, 1:2:20)
@@ -22,10 +22,10 @@
         z_left[1:2:9] = z[1:5]
         z_outer = vcat(z_left, z[6:10])
         t_outer = table((x=x_outer, y=y_outer, z=z_outer); pkey=:x)
-        @test join(t, t2; how=:outer) == t_outer
+        @test isequal(join(t, t2; how=:outer), t_outer)
     end
     @testset "how = :anti" begin 
         t_anti = table((x=2:2:10, y=y[2:2:10]), pkey=:x)
-        @test join(t, t2; how=:anti) == t_anti
+        @test isequal(join(t, t2; how=:anti), t_anti)
     end
 end

--- a/test/test_join.jl
+++ b/test/test_join.jl
@@ -17,7 +17,7 @@
     end
     @testset "how = :outer" begin 
         x_outer = union(1:10, 1:2:20)
-        y_outer = vcat(y, fill(nothing, 5))
+        y_outer = vcat(y, fill(missing, 5))
         z_left = Union{Float64,Missing}[missing for i in 1:10]
         z_left[1:2:9] = z[1:5]
         z_outer = vcat(z_left, z[6:10])

--- a/test/test_join.jl
+++ b/test/test_join.jl
@@ -1,0 +1,31 @@
+@testset "Test Joins" begin 
+    y = rand(10)
+    z = rand(10)
+
+    t  = table((x=1:10,   y=y), pkey=:x)
+    t2 = table((x=1:2:20, z=z), pkey=:x)
+
+    @testset "how = :inner" begin
+        t_inner = table((x = 1:2:9, y = y[1:2:9], z = z[1:5]), pkey = :x)
+        @test join(t, t2; how=:inner) == t_inner
+    end
+    @testset "how = :left" begin
+        z_left = Union{Float64,Missing}[missing for i in 1:10]
+        z_left[1:2:9] = z[1:5]
+        t_left = table((x = 1:10, y = y, z = z_left))
+        @test join(t, t2; how=:left)  == t_left
+    end
+    @testset "how = :outer" begin 
+        x_outer = union(1:10, 1:2:20)
+        y_outer = vcat(y, fill(nothing, 5))
+        z_left = Union{Float64,Missing}[missing for i in 1:10]
+        z_left[1:2:9] = z[1:5]
+        z_outer = vcat(z_left, z[6:10])
+        t_outer = table((x=x_outer, y=y_outer, z=z_outer); pkey=:x)
+        @test join(t, t2; how=:outer) == t_outer
+    end
+    @testset "how = :anti" begin 
+        t_anti = table((x=2:2:10, y=y[2:2:10]), pkey=:x)
+        @test join(t, t2; how=:anti) == t_anti
+    end
+end

--- a/test/test_missing.jl
+++ b/test/test_missing.jl
@@ -1,0 +1,9 @@
+@testset "Missing" begin 
+    @testset "Table equality with missing" begin 
+        table([1, 2, missing]) == table([1, 2, missing])
+    end
+    @testset "stack/unstack" begin
+        t = table(1:4, [1, missing, 9, 16], [1, 8, 27, missing], names = [:x, :x2, :x3], pkey = :x)
+        @test t == unstack(stack(t))
+    end
+end

--- a/test/test_missing.jl
+++ b/test/test_missing.jl
@@ -1,6 +1,6 @@
 @testset "Missing" begin 
     @testset "Table equality with missing" begin 
-        table([1, 2, missing]) == table([1, 2, missing])
+        @test table([1, 2, missing]) == table([1, 2, missing])
     end
     @testset "stack/unstack" begin
         t = table(1:4, [1, missing, 9, 16], [1, 8, 27, missing], names = [:x, :x2, :x3], pkey = :x)

--- a/test/test_missing.jl
+++ b/test/test_missing.jl
@@ -1,7 +1,10 @@
 @testset "Missing" begin 
     @testset "Table equality with missing" begin 
         @test ismissing(table([1, 2, missing]) == table([1, 2, missing]))
+        @test isequal(table([1,2,missing]), table([1,2,missing]))
         @test ismissing(ndsparse([1], [missing]) == ndsparse([1], [missing]))
+        @test isequal(ndsparse([1], [missing]), ndsparse([1], [missing]))
+        @test !isequal(ndsparse([2], [missing]), ndsparse([1], [missing]))
     end
     @testset "stack/unstack" begin
         t = table(1:4, [1, missing, 9, 16], [1, 8, 27, missing], names = [:x, :x2, :x3], pkey = :x)

--- a/test/test_missing.jl
+++ b/test/test_missing.jl
@@ -1,9 +1,10 @@
 @testset "Missing" begin 
     @testset "Table equality with missing" begin 
-        @test table([1, 2, missing]) == table([1, 2, missing])
+        @test ismissing(table([1, 2, missing]) == table([1, 2, missing]))
+        @test ismissing(ndsparse([1], [missing]) == ndsparse([1], [missing]))
     end
     @testset "stack/unstack" begin
         t = table(1:4, [1, missing, 9, 16], [1, 8, 27, missing], names = [:x, :x2, :x3], pkey = :x)
-        @test t == unstack(stack(t))
+        @test isequal(t, unstack(stack(t)))
     end
 end

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -1,0 +1,20 @@
+
+
+
+@testset "Tables Interface" begin 
+    n = 1000
+    x, y, z = 1:n, rand(Bool, n), randn(n)
+
+    t = table((x=x, y=y, z=z), pkey=[:x, :y])
+    nd = ndsparse((x=x, y=y), (z=z,))
+
+    @test Tables.istable(t)
+    @test Tables.istable(nd)
+    @test Tables.istable(columns(t))
+    @test Tables.istable(Columns(columns(t)))
+    @test t == table(ndsparse(t))
+    @test nd == ndsparse(table(nd))
+    for (t_row, nd_row) in zip(rows(t), rows(nd))
+        @test t_row == nd_row
+    end
+end

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -6,15 +6,8 @@
     x, y, z = 1:n, rand(Bool, n), randn(n)
 
     t = table((x=x, y=y, z=z), pkey=[:x, :y])
-    nd = ndsparse((x=x, y=y), (z=z,))
 
     @test Tables.istable(t)
-    @test Tables.istable(nd)
     @test Tables.istable(columns(t))
     @test Tables.istable(Columns(columns(t)))
-    @test t == table(ndsparse(t))
-    @test nd == ndsparse(table(nd))
-    for (t_row, nd_row) in zip(rows(t), rows(nd))
-        @test t_row == nd_row
-    end
 end

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -8,6 +8,7 @@
     t = table((x=x, y=y, z=z), pkey=[:x, :y])
 
     @test Tables.istable(t)
+    # @test t == table(Tables.rowtable((x=x,y=y,z=z)))
     @test Tables.istable(columns(t))
     @test Tables.istable(Columns(columns(t)))
 end

--- a/test/test_tabletraits.jl
+++ b/test/test_tabletraits.jl
@@ -1,7 +1,3 @@
-using IndexedTables
-using TableTraits, IteratorInterfaceExtensions
-using Test
-
 @testset "TableTraits" begin
 
 source_nds = NDSparse(Columns(a=[1,2,3]), Columns(b=[1.,2.,3.], c=["A","B","C"]))

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,5 +1,3 @@
-using Test, IndexedTables, Serialization
-
 let a = NDSparse([12,21,32], [52,41,34], [11,53,150]), b = NDSparse([12,23,32], [52,43,34], [56,13,10])
     p = vec(collect(IndexedTables.product(a, b)))
     @test p == [(11,56), (11,13), (11,10), (53,56), (53,13), (53,10), (150,56), (150,13), (150,10)]


### PR DESCRIPTION
This builds on https://github.com/JuliaComputing/IndexedTables.jl/pull/199 (Tables.jl integration) and removes the dependency on DataValues.

The build/tests are running, but I'm still unsure of the consequences of performance, integration with IterableTables, etc.  

However, we are currently in a situation where TextParse loads missing data as `Union{T,Missing}` but then operations like table joins can introduce `DataValues`.  