### PR TITLE
remove datavaluearray piracy

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,4 +6,4 @@ IteratorInterfaceExtensions 0.1.0
 TableTraits
 Tables
 StructArrays 0.2.0
-DataValues
+DataValues 0.4.6

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -18,8 +18,6 @@ ismissingtype(T, ::Type{DataValue}) = T <: DataValue
 _ismissing(x) = ismissing(x)
 _ismissing(x::DataValue) = isna(x)
 
-Base.similar(T::Type{DataValueArray{S}}, n::Dims) where {S} = DataValueArray(Vector{S}(undef, n))
-
 #-----------------------------------------------------------------------# other
 (T::Type{<:StringArray})(::typeof(undef), args...) = T(args...)
 


### PR DESCRIPTION
Now that `DataValueArray` supports the `undef` syntax (https://github.com/queryverse/DataValues.jl/pull/54) we no longer need to define `similar` with type piracy as the fallback to `DataValueArray{T}(undef, sz)` works.