### PR TITLE
remove stringarray piracy

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.7
 OnlineStatsBase 0.9.1
 PooledArrays 0.4.1
-WeakRefStrings 0.4.4
+WeakRefStrings 0.5.4
 IteratorInterfaceExtensions 0.1.0
 TableTraits
 Tables

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,7 +19,6 @@ _ismissing(x) = ismissing(x)
 _ismissing(x::DataValue) = isna(x)
 
 #-----------------------------------------------------------------------# other
-(T::Type{<:StringArray})(::typeof(undef), args...) = T(args...)
 
 fastmap(f, xs...) = map(f, xs...)
 @generated function fastmap(f, xs::NTuple{N}...) where N


### PR DESCRIPTION
After https://github.com/JuliaData/WeakRefStrings.jl/pull/48 we don't need this pirate method anymore.