### PR TITLE
Delete `cmpelts!` optimize `roweq` for PooledArrays, use it

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.7
 OnlineStatsBase 0.9.1
 PooledArrays 0.4.1
-WeakRefStrings 0.5.4
+WeakRefStrings 0.5.7
 IteratorInterfaceExtensions 0.1.0
 TableTraits
 Tables

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -91,7 +91,7 @@ end
 
 # row operations
 
-@inline roweq(x::AbstractVector, i, j) = (@inbounds eq=x[i] == x[j]; eq)
+@inline roweq(x::AbstractVector, i, j) = (@inbounds eq=isequal(x[i], x[j]); eq)
 @inline roweq(a::PooledArray, i, j) = (@inbounds x=a.refs[i] == a.refs[j]; x)
 
 copyrow!(I::Columns, i, src) = foreachfield(c->copyelt!(c, i, src), I)

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -93,6 +93,10 @@ end
 
 @inline roweq(x::AbstractVector, i, j) = (@inbounds eq=isequal(x[i], x[j]); eq)
 @inline roweq(a::PooledArray, i, j) = (@inbounds x=a.refs[i] == a.refs[j]; x)
+@inline function roweq(a::StringArray{String}, i, j)
+    weaksa = convert(StringArray{WeakRefString{UInt8}}, a)
+    @inbounds isequal(weaksa[i], weaksa[j])
+end
 
 copyrow!(I::Columns, i, src) = foreachfield(c->copyelt!(c, i, src), I)
 copyrow!(I::Columns, i, src::Columns, j) = foreachfield((c1,c2)->copyelt!(c1, i, c2, j), I, src)

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -120,7 +120,7 @@ end
     ex = :(cmp(getfield(fieldarrays(c),$N)[i], getfield(fieldarrays(d),$N)[j]))
     for n in N-1:-1:1
         ex = quote
-            let k = cmp(getfield(fieldarrays(c),$n)[i], getfield(fieldarrays(d),$n)[j])
+            let k = rowcmp(getfield(fieldarrays(c),$n), i, getfield(fieldarrays(d),$n), j)
                 (k == 0) ? ($ex) : k
             end
         end
@@ -130,6 +130,12 @@ end
 
 @inline function rowcmp(c::AbstractVector, i, d::AbstractVector, j)
     cmp(c[i], d[j])
+end
+
+@inline function rowcmp(c::StringArray{String}, i, d::StringArray{String}, j)
+    wc = convert(StringArray{WeakRefString{UInt8}}, c)
+    wd = convert(StringArray{WeakRefString{UInt8}}, d)
+    cmp(wc[i], wd[j])
 end
 
 # test that the row on the right is "as of" the row on the left, i.e.

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -87,14 +87,12 @@ end
 
 @inline copyelt!(a, i, j) = (@inbounds a[i] = a[j])
 @inline copyelt!(a, i, b, j) = (@inbounds a[i] = b[j])
-
-
 @inline copyelt!(a::PooledArray, i, j) = (a.refs[i] = a.refs[j])
 
 # row operations
 
 @inline roweq(x::AbstractVector, i, j) = (@inbounds eq=x[i] == x[j]; eq)
-@inline roweq(a::PooledArray, i, j) = (@inbounds x=cmp(a.refs[i],a.refs[j]); x)
+@inline roweq(a::PooledArray, i, j) = (@inbounds x=a.refs[i] == a.refs[j]; x)
 
 copyrow!(I::Columns, i, src) = foreachfield(c->copyelt!(c, i, src), I)
 copyrow!(I::Columns, i, src::Columns, j) = foreachfield((c1,c2)->copyelt!(c1, i, c2, j), I, src)

--- a/src/join.jl
+++ b/src/join.jl
@@ -83,15 +83,15 @@ function _join!(::Val{typ}, ::Val{grp}, ::Val{keepkeys}, f, I, data, ks, lout, r
                 # While grouping with keepkeys we want to make sure we create
                 # one group for every unique key in the output index. Hence we may
                 # need to join on smaller groups
-                while i1 < ll && rowcmp(ks, lperm[i1], ks, lperm[i1+1]) == 0
+                while i1 < ll && roweq(ks, lperm[i1], lperm[i1+1])
                     i1 += 1
                 end
             else
-                while i1 < ll && rowcmp(lkey, lperm[i1], lkey, lperm[i1+1]) == 0
+                while i1 < ll && roweq(lkey, lperm[i1], lperm[i1+1])
                     i1 += 1
                 end
             end
-            while j1 < rr && rowcmp(rkey, rperm[j1], rkey, rperm[j1+1]) == 0
+            while j1 < rr && roweq(rkey, rperm[j1], rperm[j1+1])
                 j1 += 1
             end
             if typ !== :anti
@@ -115,7 +115,7 @@ function _join!(::Val{typ}, ::Val{grp}, ::Val{keepkeys}, f, I, data, ks, lout, r
                         end
                     end
                     push!(data, group)
-                    if keepkeys && i1+1 <= ll && rowcmp(lkey, lperm[i1], lkey, lperm[i1+1]) == 0
+                    if keepkeys && i1+1 <= ll && roweq(lkey, lperm[i1], lperm[i1+1])
                         # This means that the next key on the left is equal in the lkey sense
                         # but different in the unique-key sense, so we start to make a new block again
                         i = i1 + 1


### PR DESCRIPTION
As discussed on Slack, this should prevent a large number of stringcmps in join.