### PR TITLE
Fix TableTraits source implementation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,4 @@ TableTraits
 Tables
 StructArrays 0.2.0
 DataValues 0.4.6
+TableTraitsUtils

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -3,33 +3,33 @@ module IndexedTables
 using PooledArrays, SparseArrays, Statistics, WeakRefStrings
 
 using OnlineStatsBase: OnlineStat, fit!
-using StructArrays: StructVector, StructArray, foreachfield, fieldarrays, 
-    collect_structarray, staticschema, ArrayInitializer, refine_perm!, collect_structarray, 
-    collect_empty_structarray, grow_to_structarray!, collect_to_structarray! 
+using StructArrays: StructVector, StructArray, foreachfield, fieldarrays,
+    collect_structarray, staticschema, ArrayInitializer, refine_perm!, collect_structarray,
+    collect_empty_structarray, grow_to_structarray!, collect_to_structarray!
 
-import Tables, TableTraits, IteratorInterfaceExtensions
+import Tables, TableTraits, IteratorInterfaceExtensions, TableTraitsUtils
 
 import DataValues: DataValue, DataValueArray, isna
 
 import Base:
     show, eltype, length, getindex, setindex!, ndims, map, convert, keys, values,
     ==, broadcast, empty!, copy, similar, sum, merge, merge!, mapslices,
-    permutedims, sort, sort!, iterate, pairs, reduce, push!, size, permute!, issorted, 
+    permutedims, sort, sort!, iterate, pairs, reduce, push!, size, permute!, issorted,
     sortperm, summary, resize!, vcat, append!, copyto!, view, tail,
     tuple_type_cons, tuple_type_head, tuple_type_tail, in, convert
 
 
 #-----------------------------------------------------------------------# exports
-export 
+export
     # macros
-    @cols, 
+    @cols,
     # types
     AbstractNDSparse, All, ApplyColwise, Between, ColDict, Columns, IndexedTable,
     Keys, NDSparse, NextTable, Not,
     # functions
     aggregate!, antijoin, asofjoin, collect_columns, colnames,
     column, columns, convertdim, dimlabels, flatten, flush!, groupby, groupjoin,
-    groupreduce, innerjoin, insertafter!, insertbefore!, insertcol, insertcolafter, 
+    groupreduce, innerjoin, insertafter!, insertbefore!, insertcol, insertcolafter,
     insertcolbefore, leftgroupjoin, leftjoin, map_rows, naturalgroupjoin, naturaljoin,
     ncols, ndsparse, outergroupjoin, outerjoin, pkeynames, pkeys, popcol, pushcol,
     reducedim_vec, reindex, renamecol, rows, select, selectkeys, selectvalues, setcol,

--- a/src/tabletraits.jl
+++ b/src/tabletraits.jl
@@ -4,6 +4,10 @@ function IteratorInterfaceExtensions.getiterator(source::NDSparse)
     return rows(source)
 end
 
+function IteratorInterfaceExtensions.getiterator(source::IndexedTable)
+    return TableTraitsUtils.create_tableiterator(values(columns(source)), collect(keys(columns(source))))
+end
+
 function ndsparse(x; idxcols=nothing, datacols=nothing, copy=false, kwargs...)
     if TableTraits.isiterable(x)
         source_data = collect_columns(IteratorInterfaceExtensions.getiterator(x))

--- a/test/test_tabletraits.jl
+++ b/test/test_tabletraits.jl
@@ -51,6 +51,14 @@ it4 = table(source_array, copy=true)
 @test it4[2] == (a=2,b=2.,c="B")
 @test it4[3] == (a=3,b=3.,c="C")
 
+source_nt_with_missing = table([1,missing], [missing,2.], names=[:a,:b])
+target_array_nt_with_missing = collect(getiterator(source_nt_with_missing))
+@test target_array_nt_with_missing == [(a=DataValue(1),b=DataValue{Float64}()),(a=DataValue{Int}(),b=DataValue(2.))]
+
+source_nt_with_datavalue = table([1,NA], [NA,2.], names=[:a,:b])
+target_array_nt_with_datavalue = collect(getiterator(source_nt_with_datavalue))
+@test target_array_nt_with_datavalue == [(a=DataValue(1),b=DataValue{Float64}()),(a=DataValue{Int}(),b=DataValue(2.))]
+
 # Use a Set to really hit the iterator constructor
 as_set = Set(source_array)
 it4 = table(as_set, copy=true)


### PR DESCRIPTION
TableTraits.jl sources *must* use ``DataValue`` in their row iterator to be compliant with the interface, even if the source uses ``Union{Missing,T}`` in its internal implementation. This PR adds that behavior.