### PR TITLE
initialize arrays correctly in unstack

### DIFF
--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -2,7 +2,7 @@
     stack(t, by = pkeynames(t); select = Not(by), variable = :variable, value = :value)`
 
 Reshape a table from the wide to the long format. Columns in `by` are kept as indexing columns.
-Columns in `select` are stacked. In addition to the id columns, two additional columns labeled 
+Columns in `select` are stacked. In addition to the id columns, two additional columns labeled
 `variable` and `value` are added, containing the column identifier and the stacked columns.
 See also [`unstack`](@ref).
 
@@ -53,7 +53,9 @@ function unstack(t::D, by = pkeynames(t); variable = :variable, value = :value) 
 end
 
 function unstack(::Type{D}, ::Type{T}, key, val, cols::AbstractVector{S}) where {D <:Dataset, T, S}
-    dest_val = Columns(Tuple(Array{Union{T, Missing}}(undef, length(val)) for i in cols); names = cols)
+    nulltype = Union{T, Missing}
+    n = length(val)
+    dest_val = Columns(Tuple(fill!(similar(arrayof(nulltype), n), missing) for i in cols); names = cols)
     for (i, el) in enumerate(val)
         for (k, v) in el
             ismissing(columns(dest_val, S(k))[i]) || error("Repeated values with same label are not allowed")

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -1037,7 +1037,7 @@ end
                   string.([1, 1, 4, 8, 9, 27, 16, 64]);
                   names = [:x, :var, :val], pkey = :x)
     res = table(1:4, string.([1, 4, 9, 16]), string.([1, 8, 27, 64]), names = [:x, Symbol(2), Symbol(3)], pkey = :x)
-    @test unstack(long2; variable = :var, value = :val) == res
+    @test unstack(long3; variable = :var, value = :val) == res
 end
 
 @testset "select" begin

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -646,7 +646,7 @@ end
         table((a=[1, 1, 2, 2], b=[1, 2, 1, 2], c=[1, 2, 3, 4], d=[2, 3, missing, missing]))
     )
     @test isequal(
-        join(l, r, how=:outer), 
+        join(l, r, how=:outer),
         table((a=[0, 1, 1, 2, 2, 3], b=[1, 1, 2, 1, 2, 2], c=[missing, 1, 2, 3, 4, missing], d=[1, 2, 3, missing, missing, 4]))
     )
     a = table([1],[2], names=[:x,:y])
@@ -692,7 +692,7 @@ end
 
     # null instead of missing row
     @test isequal(
-        leftjoin(+, t1, t2, lselect=2, rselect=2), 
+        leftjoin(+, t1, t2, lselect=2, rselect=2),
         table([1,2,3,4], [missing, missing, 13, 15])
     )
 
@@ -1031,6 +1031,12 @@ end
                   [1, 1, 4, 8, 9, 27, 16, 64];
                   names = [:x, :var, :val], pkey = :x)
     res = table(1:4, [1, 4, 9, 16], [1, 8, 27, 64], names = [:x, Symbol(2), Symbol(3)], pkey = :x)
+    @test unstack(long2; variable = :var, value = :val) == res
+    long3 = table([1, 1, 2, 2, 3, 3, 4, 4],
+                  [2, 3, 2, 3, 2, 3, 2, 3],
+                  string.([1, 1, 4, 8, 9, 27, 16, 64]);
+                  names = [:x, :var, :val], pkey = :x)
+    res = table(1:4, string.([1, 4, 9, 16]), string.([1, 8, 27, 64]), names = [:x, Symbol(2), Symbol(3)], pkey = :x)
     @test unstack(long2; variable = :var, value = :val) == res
 end
 


### PR DESCRIPTION
The previous initialization was incorrect, putting either garbage or undefined values instead of `missing` for missing values in `unstack`, leading e.g. to https://github.com/JuliaComputing/JuliaDB.jl/issues/263

I've also changed the initialization to `similar(arrayof(typ), n)`  rather than `Array{typ}(undef, n)` for consistency with the rest of IndexedTables.