### PR TITLE
optimize sortpermby

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,6 +5,6 @@ WeakRefStrings 0.5.7
 IteratorInterfaceExtensions 0.1.0
 TableTraits
 Tables
-StructArrays 0.2.0
+StructArrays 0.2.3
 DataValues 0.4.6
 TableTraitsUtils

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.7
 OnlineStatsBase 0.9.1
-PooledArrays 0.4.1
+PooledArrays 0.5.1
 WeakRefStrings 0.5.7
 IteratorInterfaceExtensions 0.1.0
 TableTraits

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.7
 OnlineStatsBase 0.9.1
-PooledArrays 0.5.1
+PooledArrays 0.4.1
 WeakRefStrings 0.5.7
 IteratorInterfaceExtensions 0.1.0
 TableTraits

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -5,7 +5,7 @@ using PooledArrays, SparseArrays, Statistics, WeakRefStrings
 using OnlineStatsBase: OnlineStat, fit!
 using StructArrays: StructVector, StructArray, foreachfield, fieldarrays,
     collect_structarray, staticschema, ArrayInitializer, refine_perm!, collect_structarray,
-    collect_empty_structarray, grow_to_structarray!, collect_to_structarray!
+    collect_empty_structarray, grow_to_structarray!, collect_to_structarray!, pool
 
 import Tables, TableTraits, IteratorInterfaceExtensions, TableTraitsUtils
 

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -757,4 +757,4 @@ end
 
 ### utils
 
-compact_mem(x::Columns) = Columns(map(compact_mem, columns(x)))	
+compact_mem(x::Columns) = Columns(map(compact_mem, columns(x)))

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -757,4 +757,4 @@ end
 
 ### utils
 
-compact_mem(x::Columns{<:Union{Tuple, NamedTuple}}) = Columns(map(compact_mem, columns(x)))
+compact_mem(x::Columns) = Columns(map(compact_mem, columns(x)))	

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -757,4 +757,4 @@ end
 
 ### utils
 
-compact_mem(x::Columns) = Columns(map(compact_mem, columns(x)))
+compact_mem(x::Columns{<:Union{Tuple, NamedTuple}}) = Columns(map(compact_mem, columns(x)))

--- a/src/sortperm.jl
+++ b/src/sortperm.jl
@@ -38,7 +38,7 @@ function sortpermby(t, by; cache=false)
         return partial_perm
     end
 
-    bycols = columns(t, by)
+    bycols = map(fast_sortable, columns(t, by))
     perm = if matched_cols > 0
         nxtcol = bycols[matched_cols+1]
         p = convert(Array{UInt32}, partial_perm)

--- a/src/sortperm.jl
+++ b/src/sortperm.jl
@@ -38,7 +38,7 @@ function sortpermby(t, by; cache=false)
         return partial_perm
     end
 
-    bycols = map(fast_sortable, columns(t, by))
+    bycols = map(poolstrings, columns(t, by))
     perm = if matched_cols > 0
         nxtcol = bycols[matched_cols+1]
         p = convert(Array{UInt32}, partial_perm)

--- a/src/sortperm.jl
+++ b/src/sortperm.jl
@@ -44,7 +44,7 @@ function sortpermby(t, by; cache=false)
         nxtcol = bycols[matched_cols+1]
         p = convert(Array{UInt32}, partial_perm)
         refine_perm!(p, bycols, matched_cols,
-                     rows(byrows, canonorder[1:matched_cols]),
+                     rows(byrows, Tuple(1:matched_cols)),
                      nxtcol, 1, length(t))
         p
     else

--- a/src/sortperm.jl
+++ b/src/sortperm.jl
@@ -38,16 +38,17 @@ function sortpermby(t, by; cache=false)
         return partial_perm
     end
 
-    bycols = map(StructArrays.pool, columns(t, by))
+    byrows = pool(rows(t, by))
+    bycols = columns(byrows)
     perm = if matched_cols > 0
         nxtcol = bycols[matched_cols+1]
         p = convert(Array{UInt32}, partial_perm)
         refine_perm!(p, bycols, matched_cols,
-                     rows(t, canonorder[1:matched_cols]),
+                     rows(byrows, canonorder[1:matched_cols]),
                      nxtcol, 1, length(t))
         p
     else
-        sortperm(rows(bycols))
+        sortperm(byrows)
     end
 
     if cache

--- a/src/sortperm.jl
+++ b/src/sortperm.jl
@@ -38,7 +38,7 @@ function sortpermby(t, by; cache=false)
         return partial_perm
     end
 
-    bycols = map(compact_mem, columns(t, by))
+    bycols = map(StructArrays.pool, columns(t, by))
     perm = if matched_cols > 0
         nxtcol = bycols[matched_cols+1]
         p = convert(Array{UInt32}, partial_perm)

--- a/src/sortperm.jl
+++ b/src/sortperm.jl
@@ -38,7 +38,7 @@ function sortpermby(t, by; cache=false)
         return partial_perm
     end
 
-    bycols = map(poolstrings, columns(t, by))
+    bycols = map(compact_mem, columns(t, by))
     perm = if matched_cols > 0
         nxtcol = bycols[matched_cols+1]
         p = convert(Array{UInt32}, partial_perm)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -76,7 +76,7 @@ astuple(n::NamedTuple) = Tuple(n)
 
 # optimized sortperm: pool non isbits types before calling sortperm_fast or sortperm_by
 
-sortperm_fast(x) = sortperm(StructArrays.pool(x))
+sortperm_fast(x) = sortperm(pool(x))
 
 function append_n!(X, val, n)
     l = length(X)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -74,9 +74,9 @@ astuple(t::Tuple) = t
 
 astuple(n::NamedTuple) = Tuple(n)
 
-# optimized sortperm: improve storage before calling sortperm_fast or sortperm_by
+# optimized sortperm: pool non isbits types before calling sortperm_fast or sortperm_by
 
-sortperm_fast(x) = sortperm(compact_mem(x))
+sortperm_fast(x) = sortperm(StructArrays.pool(x))
 
 function append_n!(X, val, n)
     l = length(X)
@@ -267,8 +267,7 @@ function isshared(x)
 end
 
 compact_mem(x) = x
-compact_mem(x::StringArray) = PooledArray(x)
-compact_mem(x::StringArray{String}) = compact_mem(convert(StringArray{WeakRefString{UInt8}}, x))
+compact_mem(x::StringArray{String}) = convert(StringArray{WeakRefString{UInt8}}, x)
 
 function getsubfields(n::NamedTuple, fields)
     fns = fieldnames(typeof(n))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -74,14 +74,14 @@ astuple(t::Tuple) = t
 
 astuple(n::NamedTuple) = Tuple(n)
 
-# optimized sortperm
+# optimized sortperm: replace string arrays by pooled version before calling sortperm_fast or sortperm_by
 
-sortperm_fast(x) = sortperm(fast_sortable(x))
+sortperm_fast(x) = sortperm(poolstrings(x))
 
-fast_sortable(y) = y
-fast_sortable(y::PooledArray) = PooledArrays.fast_sortable(y)
-fast_sortable(y::StringArray) = fast_sortable(PooledArray(y))
-fast_sortable(y::StringArray{String}) = fast_sortable(convert(StringArray{WeakRefString{UInt8}}, y))
+poolstrings(y) = y
+poolstrings(y::StringArray) = PooledArray(y)
+poolstrings(y::StringArray{String}) = poolstrings(convert(StringArray{WeakRefString{UInt8}}, y))
+poolstrings(y::StructVector{<:Union{Tuple, NamedTuple}}) = StructVector(map(poolstrings, columns(y)))
 
 function append_n!(X, val, n)
     l = length(X)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -74,10 +74,14 @@ astuple(t::Tuple) = t
 
 astuple(n::NamedTuple) = Tuple(n)
 
-# sortperm with counting sort
+# optimized sortperm
 
-sortperm_fast(x) = sortperm(x)
-sortperm_fast(x::StringVector) = sortperm(convert(StringVector{WeakRefString{UInt8}}, x))
+sortperm_fast(x) = sortperm(fast_sortable(x))
+
+fast_sortable(y) = y
+fast_sortable(y::PooledArray) = PooledArrays.fast_sortable(y)
+fast_sortable(y::StringArray) = fast_sortable(PooledArray(y))
+fast_sortable(y::StringArray{String}) = fast_sortable(convert(StringArray{WeakRefString{UInt8}}, y))
 
 function append_n!(X, val, n)
     l = length(X)


### PR DESCRIPTION
This moves the `fast_sortable` logic inside `sortperm_by` and `sortperm_fast`: I followed the scheme of https://github.com/piever/StructArrays.jl/pull/48 (which hopefully can be closed once this is merged) on `fast_sortable`: `StringArray{String}` goes to `StringArray{WeakRefString}`, `StringArray` gets pooled and on pooled arrays we use the same logic as what was implemented in PooledArrays (it needs the companion PR https://github.com/JuliaComputing/PooledArrays.jl/pull/21 to make sure we never end up doing the `fast_sortable` computation on PooledArrays twice). 

I hope this can restore good performance on `groupby` (end, more importantly, allows further performance tweaking without needing to change StructArrays), but have not benchmarked.

cc: @shashi @joshday 