### PR TITLE
define schema for an IndexedTable

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -9,8 +9,6 @@ Tables.columns(t::IndexedTable) = Tables.columns(columns(t))
 Tables.rowaccess(::Type{<:IndexedTable}) = true
 Tables.rows(t::IndexedTable) = Tables.rows(rows(t))
 
+Tables.schema(t::IndexedTable) = Tables.Schema(eltype(t))
+
 # table(x; copy=false, kw...) = table(Tables.columntable(x); copy=copy, kw...)
-
-
-
-

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -4,10 +4,10 @@ Tables.istable(::Type{<:IndexedTable}) = true
 Tables.materializer(t::IndexedTable) = table
 
 Tables.columnaccess(::Type{<:IndexedTable}) = true
-Tables.columns(t::IndexedTable) = Tables.columns(columns(t))
+Tables.columns(t::IndexedTable) = columns(t)
 
 Tables.rowaccess(::Type{<:IndexedTable}) = true
-Tables.rows(t::IndexedTable) = Tables.rows(rows(t))
+Tables.rows(t::IndexedTable) = rows(t)
 
 Tables.schema(t::IndexedTable) = Tables.Schema(eltype(t))
 

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -1,7 +1,7 @@
 
 
 
-@testset "Tables Interface" begin 
+@testset "Tables Interface" begin
     n = 1000
     x, y, z = 1:n, rand(Bool, n), randn(n)
 
@@ -11,4 +11,5 @@
     # @test t == table(Tables.rowtable((x=x,y=y,z=z)))
     @test Tables.istable(columns(t))
     @test Tables.istable(Columns(columns(t)))
+    @test Tables.schema(t) == Tables.Schema((:x, :y, :z), (Int, Bool, Float64))
 end

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -8,8 +8,10 @@
     t = table((x=x, y=y, z=z), pkey=[:x, :y])
 
     @test Tables.istable(t)
-    # @test t == table(Tables.rowtable((x=x,y=y,z=z)))
+    @test t == table(Tables.rowtable((x=x,y=y,z=z)))
     @test Tables.istable(columns(t))
     @test Tables.istable(Columns(columns(t)))
+    @test Tables.rowaccess(typeof(t))
+    @test Tables.columnaccess(typeof(t))
     @test Tables.schema(t) == Tables.Schema((:x, :y, :z), (Int, Bool, Float64))
 end


### PR DESCRIPTION
Tables uses `Tables.schema` to determine the type of the iterator which allows some optimizations, for example:

```julia
julia> using DataFrames, Tables

julia> df = DataFrame(x=1:10);

julia> Tables.schema(df)
Tables.Schema:
 :x  Int64
```