### PR TITLE
Simplify grouping iteration mechanism

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,6 +5,6 @@ WeakRefStrings 0.5.7
 IteratorInterfaceExtensions 0.1.0
 TableTraits
 Tables
-StructArrays 0.2.3
+StructArrays 0.3.0
 DataValues 0.4.6
 TableTraitsUtils

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,6 +5,6 @@ WeakRefStrings 0.5.7
 IteratorInterfaceExtensions 0.1.0
 TableTraits
 Tables
-StructArrays 0.2.3
+StructArrays 0.2.4
 DataValues 0.4.6
 TableTraitsUtils

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,6 +5,6 @@ WeakRefStrings 0.5.7
 IteratorInterfaceExtensions 0.1.0
 TableTraits
 Tables
-StructArrays 0.2.4
+StructArrays 0.2.3
 DataValues 0.4.6
 TableTraitsUtils

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -5,7 +5,8 @@ using PooledArrays, SparseArrays, Statistics, WeakRefStrings
 using OnlineStatsBase: OnlineStat, fit!
 using StructArrays: StructVector, StructArray, foreachfield, fieldarrays,
     collect_structarray, staticschema, ArrayInitializer, refine_perm!, collect_structarray,
-    collect_empty_structarray, grow_to_structarray!, collect_to_structarray!, pool
+    collect_empty_structarray, grow_to_structarray!, collect_to_structarray!, pool,
+    lazygroupmap
 
 import Tables, TableTraits, IteratorInterfaceExtensions, TableTraitsUtils
 

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -6,7 +6,7 @@ using OnlineStatsBase: OnlineStat, fit!
 using StructArrays: StructVector, StructArray, foreachfield, fieldarrays,
     collect_structarray, staticschema, ArrayInitializer, refine_perm!, collect_structarray,
     collect_empty_structarray, grow_to_structarray!, collect_to_structarray!, pool,
-    maptiedindices
+    GroupPerm, roweq
 
 import Tables, TableTraits, IteratorInterfaceExtensions, TableTraitsUtils
 

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -6,7 +6,7 @@ using OnlineStatsBase: OnlineStat, fit!
 using StructArrays: StructVector, StructArray, foreachfield, fieldarrays,
     collect_structarray, staticschema, ArrayInitializer, refine_perm!, collect_structarray,
     collect_empty_structarray, grow_to_structarray!, collect_to_structarray!, pool,
-    lazygroupmap
+    maptiedindices
 
 import Tables, TableTraits, IteratorInterfaceExtensions, TableTraitsUtils
 

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -35,7 +35,7 @@ Base.@pure colnames(t::Columns{<:Pair}) = colnames(t.first) => colnames(t.second
 
 Select one or more columns from an iterable of rows as a tuple of vectors.
 
-`select` specifies which columns to select. Refer to the [`select`](@ref) function for the 
+`select` specifies which columns to select. Refer to the [`select`](@ref) function for the
 available selection options and syntax.
 
 `itr` can be `NDSparse`, `Columns`, `AbstractVector`, or their distributed counterparts.
@@ -91,27 +91,12 @@ end
 
 # row operations
 
-@inline roweq(x::AbstractVector, i, j) = (@inbounds eq=isequal(x[i], x[j]); eq)
-@inline roweq(a::PooledArray, i, j) = (@inbounds x=a.refs[i] == a.refs[j]; x)
-@inline function roweq(a::StringArray{String}, i, j)
-    weaksa = convert(StringArray{WeakRefString{UInt8}}, a)
-    @inbounds isequal(weaksa[i], weaksa[j])
-end
-
 copyrow!(I::Columns, i, src) = foreachfield(c->copyelt!(c, i, src), I)
 copyrow!(I::Columns, i, src::Columns, j) = foreachfield((c1,c2)->copyelt!(c1, i, c2, j), I, src)
 copyrow!(I::AbstractArray, i, src::AbstractArray, j) = (@inbounds I[i] = src[j])
 pushrow!(to::Columns, from::Columns, i) = foreachfield((a,b)->push!(a, b[i]), to, from)
 pushrow!(to::AbstractArray, from::AbstractArray, i) = push!(to, from[i])
 
-@generated function roweq(c::Columns{D,C}, i, j) where {D,C}
-    N = fieldcount(C)
-    ex = :(roweq(getfield(fieldarrays(c),1), i, j))
-    for n in 2:N
-        ex = :(($ex) && (roweq(getfield(fieldarrays(c),$n), i, j)))
-    end
-    ex
-end
 
 # uses number of columns from `d`, assuming `c` has more or equal
 # dimensions, for broadcast joins.
@@ -368,7 +353,7 @@ end
 """
     rows(itr, select = All())
 
-Select one or more fields from an iterable of rows as a vector of their values.  Refer to 
+Select one or more fields from an iterable of rows as a vector of their values.  Refer to
 the [`select`](@ref) function for selection options and syntax.
 
 `itr` can be [`NDSparse`](@ref), `StructArrays.StructVector`, `AbstractVector`, or their distributed counterparts.
@@ -575,7 +560,7 @@ Set many columns at a time.
     setcol(t, 2 => [5,6])
     setcol(t, :y , :y => x -> x + 2)
 
-    # add [5,6] as column :z 
+    # add [5,6] as column :z
     setcol(t, :z => 5:6)
     setcol(t, :z, :y => x -> x + 2)
 
@@ -673,7 +658,7 @@ renamecol(t, args...) = @cols rename!(t, args...)
 @inline _apply(f::Tuple, y::Tuple, x::Tuple) = map(_apply, f, y, x)
 @inline _apply(f::NamedTuple, y::NamedTuple, x::NamedTuple) = map(_apply, f, y, x)
 @inline _apply(f, y, x) = f(y, x)
-@inline _apply(f::Tup, x::Tup) = _apply(astuple(f), astuple(x)) 
+@inline _apply(f::Tup, x::Tup) = _apply(astuple(f), astuple(x))
 @inline _apply(f::NamedTuple, x::NamedTuple) = map(_apply, f, x)
 @inline _apply(f::Tuple, x::Tuple) = map(_apply, f, x)
 @inline _apply(f, x) = f(x)

--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -87,7 +87,7 @@ function ndsparse(::Val{:serial}, ks::Tup, vs::Union{Tup, AbstractVector};
         d = d[p]
     elseif copy
         if agg !== nothing
-            iter = groupreduce_iter(agg, I, d, Base.OneTo(length(I)))
+            iter = igroupreduce(agg, I, d, Base.OneTo(length(I)))
             I, d = collect_columns(iter) |> columns
             agg = nothing
         else

--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -87,7 +87,7 @@ function ndsparse(::Val{:serial}, ks::Tup, vs::Union{Tup, AbstractVector};
         d = d[p]
     elseif copy
         if agg !== nothing
-            iter = GroupReduce(agg, I, d, Base.OneTo(length(I)))
+            iter = groupreduce_iter(agg, I, d, Base.OneTo(length(I)))
             I, d = collect_columns(iter) |> columns
             agg = nothing
         else

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -105,12 +105,12 @@ function groupreduce(f, t::Dataset, by=pkeynames(t);
     if !isa(by, Tuple)
         by=(by,)
     end
-    perm, keys = sortpermby(t, by, cache=cache, return_keys=true)
+    perm, key = sortpermby(t, by, cache=cache, return_keys=true)
 
     fs, input, T = init_inputs(f, data, reduced_type, false)
 
     name = isa(t, IndexedTable) ? namedtuple(nicename(f)) : nothing
-    iter = groupreduce_iter(fs, keys, input, perm; name=name)
+    iter = groupreduce_iter(fs, key, input, perm, name=name)
     convert(collectiontype(t), collect_columns(iter),
             presorted=true, copy=false)
 end

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -57,33 +57,7 @@ addname(v, name) = v
 addname(v::Tup, name::Type{<:NamedTuple}) = v
 addname(v, name::Type{<:NamedTuple}) = name((v,))
 
-struct GroupReduce{F, S, T, P, N}
-    f::F
-    key::S
-    data::T
-    perm::P
-    name::N
-    n::Int
-
-    GroupReduce(f::F, key::S, data::T, perm::P; name::N = nothing) where{F, S, T, P, N} =
-        new{F, S, T, P, N}(f, key, data, perm, name, length(key))
-end
-
-Base.IteratorSize(::Type{<:GroupReduce}) = Base.SizeUnknown()
-
-function Base.iterate(iter::GroupReduce, i1=1)
-    i1 > iter.n && return nothing
-    f, key, data, perm, n, name = iter.f, iter.key, iter.data, iter.perm, iter.n, iter.name
-    val = init_first(f, data[perm[i1]])
-    i = i1+1
-    while i <= n && roweq(key, perm[i], perm[i1])
-        val = _apply(f, val, data[perm[i]])
-        i += 1
-    end
-    (key[perm[i1]] => addname(val, name)), i
-end
-
-function groupreduce_iter(f, keys, data, perm, name)
+function groupreduce_iter(f, keys, data, perm, name=nothing)
     iter = lazygroupmap(keys, perm) do key, perm, idxs
         val = init_first(f, data[perm[first(idxs)]])
         for i in idxs[2:end]

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -58,7 +58,7 @@ addname(v::Tup, name::Type{<:NamedTuple}) = v
 addname(v, name::Type{<:NamedTuple}) = name((v,))
 
 function groupreduce_iter(f, keys, data, perm; name=nothing)
-    iter = lazygroupmap(keys, perm) do key, perm, idxs
+    iter = maptiedindices(keys, perm) do key, idxs
         val = init_first(f, data[perm[first(idxs)]])
         for i in idxs[2:end]
             val = _apply(f, val, data[perm[i]])
@@ -129,7 +129,7 @@ _apply_with_key(f::Tup, key, data, process_data) = _apply_with_key(f, key, colum
 _apply_with_key(f, key, data, process_data) = _apply(f, key, process_data(data))
 
 function groupby_iter(f, keys, data, perm; usekey=false, name=nothing)
-    lazygroupmap(keys, perm) do key, perm, idxs
+    maptiedindices(keys, perm) do key, idxs
         perm_idxs = perm[idxs]
         process_data = t -> view(t, perm_idxs)
         val = usekey ? _apply_with_key(f, key, data, process_data) :


### PR DESCRIPTION
This uses the new `lazygroupmap` (bikeshedding on the name wanted) which is a low-level function to abstract the common mechanism in the grouping functions `groupby` and `groupreduce`. `lazygroupmap(f, keys, perm)`  returns an iterator that applies `f` to `(key, perm, idxs)` where `key` is the key of the group (as a struct), `perm` is the permutation and `idxs` is the range in `perm` that corresponds to the value `key`. Both `groupby` and `groupreduce` are special cases of this operation. `lazygroupmap` (implemented in https://github.com/piever/StructArrays.jl/pull/57/files, so tests will fail until that is merged and tagged) also takes care of optimizing comparison (to compute `idxs` only the refs of pooled data are compared) so it should have good performance.

EDIT: renamed `lazygroupmap` to `maptiedindices` (`tiedindices` is the iterator that iterates the key and range in `perm` corresponding to that value, so I figured `maptiedindices` is the natural name for this).