### PR TITLE
Remove compact_mem

### DIFF
--- a/src/columns.jl
+++ b/src/columns.jl
@@ -696,7 +696,3 @@ function init_inputs(f::Tup, input, isvec)
     # functions and input
     NT((fs...,)), rows(NT((xs...,)))
 end
-
-### utils
-
-compact_mem(x::Columns) = Columns(map(compact_mem, columns(x)))

--- a/src/sortperm.jl
+++ b/src/sortperm.jl
@@ -35,10 +35,10 @@ function sortpermby(t, by; cache=false, return_keys=false)
 
     if matched_cols == length(by)
         # first n index columns
-        return return_keys ? (partial_perm, pool(compact_mem(rows(t, by)))) : partial_perm
+        return return_keys ? (partial_perm, pool(rows(t, by))) : partial_perm
     end
 
-    byrows = pool(compact_mem(rows(t, by)))
+    byrows = pool((t, by))
     bycols = columns(byrows)
     perm = if matched_cols > 0
         nxtcol = bycols[matched_cols+1]

--- a/src/sortperm.jl
+++ b/src/sortperm.jl
@@ -38,7 +38,7 @@ function sortpermby(t, by; cache=false, return_keys=false)
         return return_keys ? (partial_perm, pool(rows(t, by))) : partial_perm
     end
 
-    byrows = pool((t, by))
+    byrows = pool(rows(t, by))
     bycols = columns(byrows)
     perm = if matched_cols > 0
         nxtcol = bycols[matched_cols+1]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -266,9 +266,6 @@ function isshared(x)
     end
 end
 
-compact_mem(x) = x
-compact_mem(x::StringArray{String}) = convert(StringArray{WeakRefString{UInt8}}, x)
-
 function getsubfields(n::NamedTuple, fields)
     fns = fieldnames(typeof(n))
     NamedTuple{(fns[fields]...,)}(n)


### PR DESCRIPTION
I've optimized `pool` in StructArrays directly so that we no longer need `compact_mem`. `pool` is fast for `StringArray{String}` but it also preserves the `eltype` (unlike `compact_mem`).