### PR TITLE
remove `_promote_op`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -169,16 +169,6 @@ Base.@pure function strip_unionall(T)
     end
 end
 
-Base.@pure function _promote_op(f, ::Type{S}) where S
-    t = Core.Compiler.return_type(f, Tuple{S})
-    strip_unionall(t)
-end
-
-Base.@pure function _promote_op(f, ::Type{S}, ::Type{T}) where {S,T}
-    t = Core.Compiler.return_type(f, Tuple{S, T})
-    strip_unionall(t)
-end
-
 @inline _map(f, p::Pair) = f(p.first) => f(p.second)
 @inline _map(f, args...) = map(f, args...)
 

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -76,6 +76,10 @@ let a = NDSparse([12,21,32], [52,41,34], [11,53,150]), b = NDSparse([12,23,32], 
     @test sum(map(-, c, c)) == 0
 
     @test map(iseven, a) == NDSparse([12,21,32], [52,41,34], [false,false,true])
+
+    # 97
+    x = ndsparse((t=[0.01, 0.05],), (x=[1,2], y=[3,4],))
+    @test map(p->(r = sum(p),), x).data == Columns(([4,6],), names=[:r])
 end
 
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -33,32 +33,3 @@ let x = rand(3), y = rand(3), v = rand(3), w = rand(3)
     @test vcat((Columns((x,y))), Columns((v,w))) == Columns((vcat(x,v), vcat(y,w)))
     @test vcat(Columns(x=x,y=y), Columns(x=v,y=w)) == Columns(x=vcat(x,v), y=vcat(y,w))
 end
-
-import IndexedTables: _promote_op
-
-let
-    f = x -> 1/x
-    @test _promote_op(f, Int) == Float64
-
-    f = x -> (x,1/x)
-    @test _promote_op(f, Int) == Tuple{Int, Float64}
-
-    foo(i) = [1, 1//2, "x"][i]
-    f = x -> (x,foo(x))
-    @test _promote_op(f, Int) == Tuple{Int, Any}
-
-    bar(i) = Union{Int, String}[1, "x"][i]
-    g = x -> (x,bar(x))
-    @test _promote_op(g, Int) == Tuple{Int, Any}
-
-    h = x -> rand(Bool) ? (x=1,) : (y=2,)
-    @test _promote_op(h, Int) <: NamedTuple
-
-    #101
-    s = (1,)
-    @test _promote_op(i -> Tuple(getfield(i, j) for j in s), Tuple{Int}) == Any
-
-    # 97
-    x = ndsparse((t=[0.01, 0.05],), (x=[1,2], y=[3,4],))
-    @test map(p->(r = sum(p),), x).data == Columns(([4,6],), names=[:r])
-end


### PR DESCRIPTION
After the release of JuliaDB gets merged I think we might as well remove `_promote_op`: it's a private function that we no longer need.