### PR TITLE
fix rendering bug for table of large vectors

### DIFF
--- a/src/indexedtable.jl
+++ b/src/indexedtable.jl
@@ -418,8 +418,7 @@ function showtable(io::IO, t; header=nothing, cnames=colnames(t), divider=nothin
         end
     end
     nc = length(columns(t))
-
-    reprs  = [ sprint(io->show(IOContext(io, :compact => true), columns(t)[j][i])) for i in rows, j in 1:nc ]
+    reprs  = [ sprint(io->show(IOContext(io, :compact => true, :limit => true), columns(t)[j][i])) for i in rows, j in 1:nc ]
     strcnames = map(string, cnames)
     widths  = [ max(textwidth(get(strcnames, c, "")), isempty(reprs) ? 0 : maximum(map(textwidth, reprs[:,c]))) for c in 1:nc ]
     if compact && !isempty(widths) && sum(widths) + 2*nc > width


### PR DESCRIPTION
Fixes #231. Turns out in `IOContext` we also need `:limit => true` as only `:compact => true` would still print all elements for a long vector.