### PR TITLE
rename pool back to compact_mem and implement here

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -6,7 +6,7 @@ using OnlineStatsBase: OnlineStat, fit!
 
 using StructArrays: StructVector, StructArray, foreachfield, fieldarrays,
     collect_structarray, staticschema, ArrayInitializer, refine_perm!, collect_structarray,
-    collect_empty_structarray, grow_to_structarray!, collect_to_structarray!, pool,
+    collect_empty_structarray, grow_to_structarray!, collect_to_structarray!, replace_storage,
     GroupPerm, GroupJoinPerm, roweq, rowcmp, fastpermute!
 
 import Tables, TableTraits, IteratorInterfaceExtensions, TableTraitsUtils

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -696,3 +696,6 @@ function init_inputs(f::Tup, input, isvec)
     # functions and input
     NT((fs...,)), rows(NT((xs...,)))
 end
+
+# utils
+compact_mem(v::Columns) = replace_storage(compact_mem, v)

--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -398,7 +398,7 @@ function aggregate!(f, x::NDSparse)
     idxs, data = x.index, x.data
     n = length(idxs)
     newlen = 0
-    for ii in GroupPerm(pool(idxs), Base.OneTo(n))
+    for ii in GroupPerm(compact_mem(idxs), Base.OneTo(n))
         newlen += 1
         if newlen != last(ii)
             copyrow!(idxs, newlen, last(ii))

--- a/src/sortperm.jl
+++ b/src/sortperm.jl
@@ -35,10 +35,10 @@ function sortpermby(t, by; cache=false, return_keys=false)
 
     if matched_cols == length(by)
         # first n index columns
-        return return_keys ? (partial_perm, pool(rows(t, by))) : partial_perm
+        return return_keys ? (partial_perm, compact_mem(rows(t, by))) : partial_perm
     end
 
-    byrows = pool(rows(t, by))
+    byrows = compact_mem(rows(t, by))
     bycols = columns(byrows)
     perm = if matched_cols > 0
         nxtcol = bycols[matched_cols+1]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -76,7 +76,7 @@ astuple(n::NamedTuple) = Tuple(n)
 
 # optimized sortperm: pool non isbits types before calling sortperm_fast or sortperm_by
 
-sortperm_fast(x) = sortperm(pool(x))
+sortperm_fast(x) = sortperm(compact_mem(x))
 
 function append_n!(X, val, n)
     l = length(X)
@@ -266,3 +266,10 @@ getsubfields(t::Tuple, fields) = t[fields]
 
 product(itr) = itr
 product(itrs...) = Base.Generator(reverse, Iterators.product(reverse(itrs)...))
+
+# pool non isbits types
+
+compact_mem(v::PooledArray) = v
+compact_mem(v::AbstractArray{T}) where {T} = isbitstype(T) ? v : PooledArray(v)
+compact_mem(v::StringArray{String}) =
+    map(String, PooledArray(convert(StringArray{WeakRefString{UInt8}}, v)))


### PR DESCRIPTION
In a discussion on making DataFrames more lightweight (ref: https://github.com/JuliaData/DataFrames.jl/issues/1764), it was pointed out that StructArrays also got a bit of bloat (which feels unnecessary for people using it for things other than data analysis). I have a plan to get rid of the PooledArrays dependency and Requires use for WeakRefStrings, but it requires moving the "pooling" functionality back here, so I've renamed `pool` (that we took from StructArrays) to the old name of `compact_mem` (pool is wrong anyway as we are only pooling some columns) and moved the implementation here (in the future I will deprecate the implementation in StructArrays when I get rid of the dependencies).