### PR TITLE
Fix #237 : join with empty data

### DIFF
--- a/src/columns.jl
+++ b/src/columns.jl
@@ -347,6 +347,10 @@ rows(cols::Tup) = Columns(cols)
 
 rows(t, which...) = rows(columns(t, which...))
 
+replace_placeholder(t, ::Columns{Tuple{}}) = fill(Tuple(), length(t))
+replace_placeholder(t, ::Columns{NamedTuple{(), Tuple{}}}) = fill(NamedTuple(), length(t))
+replace_placeholder(t, cols) = cols
+
 _cols_tuple(xs::Columns) = columns(xs)
 _cols_tuple(xs::AbstractArray) = (xs,)
 concat_cols(xs, ys) = rows(concat_tup(_cols_tuple(xs), _cols_tuple(ys)))

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -347,6 +347,7 @@ rows(cols::Tup) = Columns(cols)
 
 rows(t, which...) = rows(columns(t, which...))
 
+# Replace empty Columns object with one of correct length and eltype
 replace_placeholder(t, ::Columns{Tuple{}}) = fill(Tuple(), length(t))
 replace_placeholder(t, ::Columns{NamedTuple{(), Tuple{}}}) = fill(NamedTuple(), length(t))
 replace_placeholder(t, cols) = cols

--- a/src/join.jl
+++ b/src/join.jl
@@ -177,6 +177,9 @@ function Base.join(f, left::Dataset, right::Dataset;
         (how == :inner) || (rdata = nullablerows(rdata, missingtype))
     end
 
+    ldata = replace_placeholder(left, ldata)
+    rdata = replace_placeholder(right, rdata)
+
     KT = map_params(promote_type, eltype(lkey), eltype(rkey))
     lkey = Columns{KT}(fieldarrays(lkey))
     rkey = Columns{KT}(fieldarrays(rkey))

--- a/test/test_join.jl
+++ b/test/test_join.jl
@@ -52,4 +52,10 @@
         @test isequal(join(a, b, how=:outer, lkey=:id, rkey=:id), t_outer)
         @test isequal(join(a, b, how=:outer, lkey=:id, rkey=:id, missingtype=DataValue), t_outer2)
     end
+    @testset "empty" begin
+        t1 = table((key = ["a","b","c"], ))
+        t2 = table((key = ["a","b"], value = [1,2]))
+        res = join(t1, t2, how = :left, lkey = :key, rkey = :key)
+        @test isequal(res, table((key = ["a","b","c"], value = [1,2,missing])))
+    end
 end


### PR DESCRIPTION
This fixes issue #237 by replacing the placeholder one normally gets with `rows(t, ())` with an array of correct length and `eltype`. I initially thought it was better to change the default behavior of `rows(t, ())` but that definitely deserves more discussion.