### PR TITLE
 deprecate popcol, pushcol and setcol

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -33,9 +33,9 @@ export
     column, columns, convertdim, dimlabels, flatten, flush!, groupby, groupjoin,
     groupreduce, innerjoin, insertafter!, insertbefore!, insertcol, insertcolafter,
     insertcolbefore, leftgroupjoin, leftjoin, map_rows, naturalgroupjoin, naturaljoin,
-    ncols, ndsparse, outergroupjoin, outerjoin, pkeynames, pkeys, popcol, pushcol,
-    reducedim_vec, reindex, renamecol, rows, select, selectkeys, selectvalues, setcol,
-    stack, summarize, table, unstack, update!, where, dropmissing, dropna
+    ncols, ndsparse, outergroupjoin, outerjoin, pkeynames, pkeys,
+    reducedim_vec, reindex, renamecol, rows, select, selectkeys, selectvalues,
+    stack, summarize, table, transform, unstack, update!, where, dropmissing, dropna
 
 const Tup = Union{Tuple,NamedTuple}
 const DimName = Union{Int,Symbol}

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -530,6 +530,7 @@ transform(t, args...) = @cols transform!(t, args...)
 @deprecate pushcol(t, args) transform(t, args)
 
 @deprecate popcol(t, args...) select(t, Not(args...))
+@deprecate popcol(t) select(t, Not(ncols(t)))
 
 """
     insertcol(t, position::Integer, name, x)

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -392,7 +392,7 @@ end
 Base.getindex(d::ColDict, key) = rows(d[], key)
 Base.getindex(d::ColDict, key::AbstractArray) = key
 
-function Base.setindex!(d::ColDict, x, key::Union{Symbol, Int})
+function Base.setindex!(d::ColDict, x, key::Union{Symbol, Integer})
     k = _colindex(d.names, key, 0)
     col = d[x]
     if k == 0
@@ -410,7 +410,15 @@ function Base.setindex!(d::ColDict, x, key::Union{Symbol, Int})
     end
 end
 
-set!(d::ColDict, key::Union{Symbol, Int}, x) = setindex!(d, x, key)
+Base.@deprecate set!(d::ColDict, key, x) setindex!(d, x, key)
+
+transform!(d::ColDict, changes::Pair...) = transform!(d, changes)
+
+function transform!(d::ColDict, changes)
+    foreach(changes) do (key, val)::Pair
+        d[key] = val
+    end
+end
 
 function Base.haskey(d::ColDict, key)
     _colindex(d.names, key, 0) != 0
@@ -446,31 +454,7 @@ function insertbefore!(d::ColDict, i, key, col)
     insert!(d, k, key, col)
 end
 
-function Base.pop!(d::ColDict, key::Union{Symbol, Int}=length(d.names))
-    k = _colindex(d.names, key, 0)
-    local col
-    if k == 0
-        error("Column $key not found")
-    else
-        col = d.columns[k]
-        deleteat!(d.names, k)
-        deleteat!(d.columns, k)
-        idx = [pk[1] for pk in enumerate(d.pkey) if pk[2] == k]
-        deleteat!(d.pkey, idx)
-        for i in 1:length(d.pkey)
-            if d.pkey[i] > k
-                d.pkey[i] -= 1
-            end
-        end
-        if !isempty(idx) && d.copy === nothing
-            # set copy to true
-            d.copy = true
-        end
-    end
-    col
-end
-
-function rename!(d::ColDict, col::Union{Symbol, Int}, newname)
+function rename!(d::ColDict, (col, newname)::Pair)
     k = _colindex(d.names, col, 0)
     if k == 0
         error("$col not found. Cannot rename it.")
@@ -478,27 +462,14 @@ function rename!(d::ColDict, col::Union{Symbol, Int}, newname)
     d.names[k] = newname
 end
 
-Base.push!(d::ColDict, key::AbstractString, x) = push!(d, Symbol(key), x)
-function Base.push!(d::ColDict, key::Union{Symbol, Int}, x)
+@deprecate rename!(t::ColDict, col::Union{Symbol, Integer}, newname) rename!(t, col => newname)
+
+rename!(t::ColDict, changes) = foreach(change::Pair -> rename!(t, change), changes)
+rename!(t::ColDict, changes::Pair...) = rename!(t, changes)
+
+function Base.push!(d::ColDict, (key, x)::Pair)
     push!(d.names, key)
     push!(d.columns, rows(d.src, x))
-end
-
-for s in [:(Base.pop!), :(Base.push!), :(rename!), :(set!)]
-    if s == :(Base.pop!)
-        typ = :(Union{Symbol, Int})
-    else
-        typ = :Pair
-        @eval $s(t::ColDict, x::Pair) = $s(t, x.first, x.second)
-    end
-    @eval begin
-        function $s(t::ColDict, args)
-            for i in args
-                $s(t, i)
-            end
-        end
-        $s(t::ColDict, args::Vararg{$typ}) = $s(t, args)
-    end
 end
 
 function _cols(expr)
@@ -520,63 +491,45 @@ macro cols(expr)
     _cols(expr)
 end
 
-# Modifying a columns
+# Modifying columns
 
 """
-    setcol(t::Table, col::Union{Symbol, Int}, x::Selection)
+    transform(t::Table, changes::Pair...)
 
-Sets a `x` as the column identified by `col`. Returns a new table.
-
-    setcol(t::Table, map::Pair{}...)
-
-Set many columns at a time.
+Transform columns of `t`. For each pair `col => value` in `changes` the column `col` is replaced
+by the `AbstractVector` `value`. If `col` is not an existing column, a new column is created.
 
 # Examples:
 
     t = table([1,2], [3,4], names=[:x, :y])
 
     # change second column to [5,6]
-    setcol(t, 2 => [5,6])
-    setcol(t, :y , :y => x -> x + 2)
+    transform(t, 2 => [5,6])
+    transform(t, :y => :y => x -> x + 2)
 
     # add [5,6] as column :z
-    setcol(t, :z => 5:6)
-    setcol(t, :z, :y => x -> x + 2)
+    transform(t, :z => 5:6)
+    transform(t, :z => :y => x -> x + 2)
 
     # replacing the primary key results in a re-sorted copy
     t = table([0.01, 0.05], [1,2], [3,4], names=[:t, :x, :y], pkey=:t)
-    t2 = setcol(t, :t, [0.1,0.05])
-"""
-setcol(t, args...) = @cols set!(t, args...)
+    t2 = transform(t, :t => [0.1,0.05])
 
-"""
-    pushcol(t, name, x)
-
-Push a column `x` to the end of the table. `name` is the name for the new column. Returns a new table.
-
-    pushcol(t, map::Pair...)
-
-Push many columns at a time.
-
-# Example
-
+    # the column :z is not part of t so a new column is added
     t = table([0.01, 0.05], [2,1], [3,4], names=[:t, :x, :y], pkey=:t)
-    pushcol(t, :z, [1//2, 3//4])
     pushcol(t, :z => [1//2, 3//4])
 """
-pushcol(t, args...) = @cols push!(t, args...)
+transform(t, args...) = @cols transform!(t, args...)
 
-"""
-    popcol(t, cols...)
+@deprecate setcol(t, args::Pair...) transform(t, args...)
+@deprecate setcol(t, key::Union{Int, Symbol}, val) transform(t, key => val)
+@deprecate setcol(t, args) transform(t, args)
 
-Remove the column(s) `cols` from the table. Returns a new table.
+@deprecate pushcol(t, args::Pair...) transform(t, args...)
+@deprecate pushcol(t, key::Union{Int, Symbol}, val) transform(t, key => val)
+@deprecate pushcol(t, args) transform(t, args)
 
-# Example
-
-    t = table([0.01, 0.05], [2,1], [3,4], names=[:t, :x, :y], pkey=:t)
-    popcol(t, :x)
-"""
-popcol(t, args...) = @cols pop!(t, args...)
+@deprecate popcol(t, args...) select(t, Not(args...))
 
 """
     insertcol(t, position::Integer, name, x)

--- a/src/indexedtable.jl
+++ b/src/indexedtable.jl
@@ -292,6 +292,8 @@ end
 # for a table, selecting the "value" means selecting all fields
 valuenames(t::AbstractIndexedTable) = (colnames(t)...,)
 
+ncols(t::AbstractIndexedTable) = length(colnames(t))
+
 """
     pkeys(itr::IndexedTable)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
-using Test, IndexedTables, OnlineStats, WeakRefStrings, Tables, Random, Dates, 
+using Test, IndexedTables, OnlineStats, WeakRefStrings, Tables, Random, Dates,
     PooledArrays, SparseArrays, WeakRefStrings, LinearAlgebra, Statistics,
     TableTraits, IteratorInterfaceExtensions, Serialization, DataValues
 
 using IndexedTables: excludecols, sortpermby, primaryperm, best_perm_estimate, hascolumns,
-    collect_columns_flattened
+    collect_columns_flattened, transform
 
 include("test_tables.jl")
 include("test_missing.jl")

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -554,45 +554,43 @@ end
 
 @testset "column manipulation" begin
     t = table([1, 2], [3, 4], names=[:x, :y])
-    @test setcol(t, 2, [5, 6]) == table([1, 2], [5, 6], names=Symbol[:x, :y])
-    @test setcol(t, 2 => [5, 6]) == setcol(t, 2, [5, 6])
-    @test setcol(t, 2 => [5, 6], 1 => [7, 12]) == table([7, 12], [5, 6], names=Symbol[:x, :y]) ==
-        setcol(t, (2 => [5, 6], 1 => [7, 12]))
-    @test setcol(t, :x, :x => (x->1 / x)) == table([1.0, 0.5], [3, 4], names=Symbol[:x, :y])
+    @test transform(t, 2 => [5, 6]) == table([1, 2], [5, 6], names=Symbol[:x, :y])
+    @test transform(t, 2 => [5, 6], 1 => [7, 12]) == table([7, 12], [5, 6], names=Symbol[:x, :y]) ==
+        transform(t, (2 => [5, 6], 1 => [7, 12]))
+    @test transform(t, :x => :x => (x->1 / x)) == table([1.0, 0.5], [3, 4], names=Symbol[:x, :y])
     t = table([0.01, 0.05], [1, 2], [3, 4], names=[:t, :x, :y], pkey=:t)
-    t2 = setcol(t, :t, [0.1, 0.05])
+    t2 = transform(t, :t => [0.1, 0.05])
     @test t2 == table([0.05, 0.1], [2,1], [4,3], names=[:t,:x,:y])
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t)
-    @test pushcol(t, :z, [1 // 2, 3 // 4]) == table([0.01, 0.05], [2, 1], [3, 4], [1//2, 3//4], names=Symbol[:t, :x, :y, :z])
-    @test pushcol(t, :z => [1 // 2, 3 // 4]) == pushcol(t, :z, [1 // 2, 3 // 4])
-    @test pushcol(t, :z => [1 // 2, 3 // 4], :w => [0, 1]) ==
+    @test transform(t, :z => [1 // 2, 3 // 4]) == table([0.01, 0.05], [2, 1], [3, 4], [1//2, 3//4], names=Symbol[:t, :x, :y, :z])
+    @test transform(t, :z => [1 // 2, 3 // 4], :w => [0, 1]) ==
         table([0.01, 0.05], [2, 1], [3, 4], [1//2, 3//4], [0, 1], names=Symbol[:t, :x, :y, :z, :w]) ==
-        pushcol(t, (:z => [1 // 2, 3 // 4], :w => [0, 1]))
+        transform(t, (:z => [1 // 2, 3 // 4], :w => [0, 1]))
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=(:t,:x))
-    @test popcol(t, :t) == table([1, 2], [4,3], names=Symbol[:x, :y])
-    @test popcol(t) == table([0.01, 0.05], [2, 1], names=Symbol[:t, :x])
-    @test popcol(t, :x, :y) == table([0.01, 0.05], names=Symbol[:t]) == popcol(t, (:x, :y))
-    @test pushcol(t, :z, [1 // 2, 3 // 4]) == table([0.01, 0.05], [2, 1], [3, 4], [1//2, 3//4], names=Symbol[:t, :x, :y, :z])
+    @test select(t, Not(:t)) == table([1, 2], [4,3], names=Symbol[:x, :y])
+    @test select(t, Not(ncols(t))) == table([0.01, 0.05], [2, 1], names=Symbol[:t, :x])
+    @test select(t, Not(:x, :y)) == table([0.01, 0.05], names=Symbol[:t]) == select(t, Not((:x, :y)))
+    @test transform(t, :z => [1 // 2, 3 // 4]) == table([0.01, 0.05], [2, 1], [3, 4], [1//2, 3//4], names=Symbol[:t, :x, :y, :z])
 
     # 99
-    @test popcol(t, :x).pkey == [1]
+    @test select(t, Not(:x)).pkey == [1]
 
     # "Copy-on write"
     t = table([1,2,3], [4,5,6], names=[:x,:y], pkey=:x)
     tcopy = copy(t)
-    @test column(pushcol(t, :z, [7,8,9]), :x) === column(t, :x)
+    @test column(transform(t, :z => [7,8,9]), :x) === column(t, :x)
     @test t == tcopy
 
-    @test column(setcol(t, :y, [7,8,9]), :x) === column(t, :x)
+    @test column(transform(t, :y => [7,8,9]), :x) === column(t, :x)
     @test t == tcopy
 
     # seting or popping an index column causes copy
-    t2 = setcol(t, :x, [9,8,7])
+    t2 = transform(t, :x => [9,8,7])
     @test column(t2, :y) !== column(t, :y)
     @test t == tcopy
     @test t2 == table([7,8,9], [6,5,4], names=[:x, :y])
 
-    t2 = popcol(t, :x)
+    t2 = select(t, Not(:x))
     @test column(t2, :y) !== column(t, :y)
     @test t == tcopy
     @test t2 == table([4,5,6], names=[:y])
@@ -604,9 +602,9 @@ end
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t)
     @test insertcolbefore(t, :x, :w, [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
     t = table([0.01, 0.05], [2, 1], names=[:t, :x])
-    @test renamecol(t, :t, :time) == table([0.01, 0.05], [2, 1], names=Symbol[:time, :x])
-    @test_throws ErrorException renamecol(t, :tt, :time)
-    @test renamecol(t, :t => :time) == renamecol(t, :t, :time)
+    @test renamecol(t, :t => :time) == table([0.01, 0.05], [2, 1], names=Symbol[:time, :x])
+    @test_throws ErrorException renamecol(t, :tt => :time)
+    @test renamecol(t, :t => :time) == renamecol(t, :t => :time)
     @test renamecol(t, :t => :time, :x => :position) ==
         table([0.01, 0.05], [2, 1], names=Symbol[:time, :position]) ==
         renamecol(t, (:t => :time, :x => :position))
@@ -933,7 +931,7 @@ using OnlineStats
     b = table(Columns(a=[1, 1, 2], b=[3, 2, 2], c=[4, 5, 2]), pkey=(1,2))
 
     @test groupreduce(min, a, select=3) == a
-    @test groupreduce(min, b, select=3) == renamecol(b, :c, :min)
+    @test groupreduce(min, b, select=3) == renamecol(b, :c => :min)
     @test_throws ArgumentError groupreduce(+, b, [:x, :y]) # issue JuliaDB.jl#100
     t = table([1, 1, 1, 2, 2, 2], [1, 1, 2, 2, 1, 1], [1, 2, 3, 4, 5, 6], names=[:x, :y, :z], pkey=(:x, :y))
     @test groupreduce(+, t, :x, select=:z) == table([1, 2], [6, 15], names=Symbol[:x, :+])
@@ -1168,7 +1166,7 @@ end
     @test flatten(x, :y) == table([1,1,2,2], [3,4,7,8], [5,6,9,10], names=[:x,:a, :b])
     x = table([1,2], [(2i for i in 1:3 if isodd(i)), (5, nothing)])
     @test flatten(x) == table(([1,1,2,2], [2,6,5,nothing]))
-    
+
     # test that isiterable_val output is known statically
     f(x) = IndexedTables.isiterable_val(x) ? x : nothing
     val1 = @inferred f([1, 2])
@@ -1180,7 +1178,7 @@ end
     @test groupby((:normy => x->Iterators.repeated(mean(x), length(x)),),
                   t, :x, select=:y, flatten=true) == table([1,1,2,2], [3.5,3.5,5.5,5.5], names=[:x, :normy])
     t=table([1,1,1,2,2,2], [1,1,2,1,1,2], [1,2,3,4,5,6], names=[:x,:y,:z], pkey=[1,2]);
-    @test groupby(identity, t, (:x, :y), select=:z, flatten = true) == renamecol(t, :z, :identity)
+    @test groupby(identity, t, (:x, :y), select=:z, flatten = true) == renamecol(t, :z => :identity)
     @test groupby(identity, t, (:x, :y), select=:z, flatten = true).pkey == [1,2]
     # If return type is non iterable, return the same as non flattened
     @test groupby(i -> (y = :y,), t, :x, flatten=true) == groupby(i -> (y = :y,), t, :x, flatten=false)


### PR DESCRIPTION
First part of #239. Here I'm deprecating `popcol(t, cols)` in favor of `select(t, Not(cols))` and `pushcol` and `setcol` are replaced by `transform`. I changes some generated code into normal code for readability as it is only needed for `rename!` now. I also did a bit of clean-up removing `ColDict` methods that were no longer needed.