### PR TITLE
Switch renamecol to rename and insertcol to insertcols, add multiple column version

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -34,7 +34,7 @@ export
     groupreduce, innerjoin, insertafter!, insertbefore!, insertcols, insertcolsafter,
     insertcolsbefore, leftgroupjoin, leftjoin, map_rows, naturalgroupjoin, naturaljoin,
     ncols, ndsparse, outergroupjoin, outerjoin, pkeynames, pkeys,
-    reducedim_vec, reindex, renamecols, rows, select, selectkeys, selectvalues,
+    reducedim_vec, reindex, rename, rows, select, selectkeys, selectvalues,
     stack, summarize, table, transform, unstack, update!, where, dropmissing, dropna
 
 const Tup = Union{Tuple,NamedTuple}

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -31,10 +31,10 @@ export
     # functions
     aggregate!, antijoin, asofjoin, collect_columns, colnames,
     column, columns, convertdim, dimlabels, flatten, flush!, groupby, groupjoin,
-    groupreduce, innerjoin, insertafter!, insertbefore!, insertcol, insertcolafter,
-    insertcolbefore, leftgroupjoin, leftjoin, map_rows, naturalgroupjoin, naturaljoin,
+    groupreduce, innerjoin, insertafter!, insertbefore!, insertcols, insertcolsafter,
+    insertcolsbefore, leftgroupjoin, leftjoin, map_rows, naturalgroupjoin, naturaljoin,
     ncols, ndsparse, outergroupjoin, outerjoin, pkeynames, pkeys,
-    reducedim_vec, reindex, renamecol, rows, select, selectkeys, selectvalues,
+    reducedim_vec, reindex, renamecols, rows, select, selectkeys, selectvalues,
     stack, summarize, table, transform, unstack, update!, where, dropmissing, dropna
 
 const Tup = Union{Tuple,NamedTuple}

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -424,7 +424,7 @@ function Base.haskey(d::ColDict, key)
     _colindex(d.names, key, 0) != 0
 end
 
-function Base.insert!(d::ColDict, index, key, col)
+function Base.insert!(d::ColDict, index::Integer, (key, col)::Pair)
     if haskey(d, key)
         error("Key $key already exists. Use dict[key] = col instead of inserting.")
     else
@@ -438,20 +438,29 @@ function Base.insert!(d::ColDict, index, key, col)
     end
 end
 
-function insertafter!(d::ColDict, i, key, col)
-    k = _colindex(d.names, i, 0)
-    if k == 0
-        error("$i not found. Cannot insert column after $i")
+function Base.insert!(d::ColDict, index::Integer, newcols)
+    for new::Pair in newcols
+        insert!(d, index, new)
+        index += 1
     end
-    insert!(d, k+1, key, col)
 end
 
-function insertbefore!(d::ColDict, i, key, col)
+Base.insert!(d::ColDict, index::Integer, newcols::Pair...) = insert!(d, index, newcols)
+
+function insertafter!(d::ColDict, i, args...)
     k = _colindex(d.names, i, 0)
     if k == 0
         error("$i not found. Cannot insert column after $i")
     end
-    insert!(d, k, key, col)
+    insert!(d, k+1, args...)
+end
+
+function insertbefore!(d::ColDict, i, args...)
+    k = _colindex(d.names, i, 0)
+    if k == 0
+        error("$i not found. Cannot insert column after $i")
+    end
+    insert!(d, k, args...)
 end
 
 function rename!(d::ColDict, (col, newname)::Pair)
@@ -533,56 +542,64 @@ transform(t, args...) = @cols transform!(t, args...)
 @deprecate popcol(t) select(t, Not(ncols(t)))
 
 """
-    insertcol(t, position::Integer, name, x)
+    insertcols(t, position::Integer, map::Pair...)
 
-Insert a column `x` named `name` at `position`. Returns a new table.
-
-# Example
-
-    t = table([0.01, 0.05], [2,1], [3,4], names=[:t, :x, :y], pkey=:t)
-    insertcol(t, 2, :w, [0,1])
-"""
-insertcol(t, i::Integer, name, x) = @cols insert!(t, i, name, x)
-
-"""
-    insertcolafter(t, after, name, col)
-
-Insert a column `col` named `name` after `after`. Returns a new table.
+For each pair `name => col` in `map`, insert a column `col` named `name` starting at `position`.
+Returns a new table.
 
 # Example
 
     t = table([0.01, 0.05], [2,1], [3,4], names=[:t, :x, :y], pkey=:t)
-    insertcolafter(t, :t, :w, [0,1])
+    insertcol(t, 2, :w => [0,1])
 """
-insertcolafter(t, after, name, x) = @cols insertafter!(t, after, name, x)
+insertcols(t, i::Integer, args...) = @cols insert!(t, i, args...)
+
+@deprecate insertcol(t, i, name, x) insertcols(t, i, name => x)
 
 """
-    insertcolbefore(t, before, name, col)
+    insertcolsafter(t, after, map::Pair...)
 
-Insert a column `col` named `name` before `before`. Returns a new table.
+For each pair `name => col` in `map`, insert a column `col` named `name` after `after`.
+Returns a new table.
 
 # Example
 
     t = table([0.01, 0.05], [2,1], [3,4], names=[:t, :x, :y], pkey=:t)
-    insertcolbefore(t, :x, :w, [0,1])
+    insertcolsafter(t, :t, :w => [0,1])
 """
-insertcolbefore(t, before, name, x) = @cols insertbefore!(t, before, name, x)
+insertcolsafter(t, after, args...) = @cols insertafter!(t, after, args...)
+
+@deprecate insertcolafter(t, i, name, x) insertcolsafter(t, i, name => x)
 
 """
-    renamecol(t, col, newname)
+insertcolsbefore(t, before, map::Pair...)
 
-Set `newname` as the new name for column `col` in `t`. Returns a new table.
+For each pair `name => col` in `map`, insert a column `col` named `name` before `before`.
+Returns a new table.
 
-    renamecol(t, map::Pair...)
+# Example
 
-Rename multiple columns at a time.
+    t = table([0.01, 0.05], [2,1], [3,4], names=[:t, :x, :y], pkey=:t)
+    insertcolsbefore(t, :x, :w => [0,1])
+"""
+insertcolsbefore(t, before, args...) = @cols insertbefore!(t, before, args...)
+
+@deprecate insertcolbefore(t, i, name, x) insertcolsbefore(t, i, name => x)
+
+"""
+    renamecols(t, map::Pair...)
+
+For each pair `col => newname` in `map`, set `newname` as the new name for column `col` in `t`.
+Returns a new table.
 
 # Example
 
     t = table([0.01, 0.05], [2,1], names=[:t, :x])
-    renamecol(t, :t, :time)
+    renamecols(t, :t => :time)
 """
-renamecol(t, args...) = @cols rename!(t, args...)
+renamecols(t, args...) = @cols rename!(t, args...)
+
+@deprecate renamecol(t, args...) renamecols(t, args...)
 
 ## Utilities for mapping and reduction with many functions / OnlineStats
 

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -587,7 +587,7 @@ insertcolsbefore(t, before, args...) = @cols insertbefore!(t, before, args...)
 @deprecate insertcolbefore(t, i, name, x) insertcolsbefore(t, i, name => x)
 
 """
-    renamecols(t, map::Pair...)
+    rename(t, map::Pair...)
 
 For each pair `col => newname` in `map`, set `newname` as the new name for column `col` in `t`.
 Returns a new table.
@@ -595,11 +595,11 @@ Returns a new table.
 # Example
 
     t = table([0.01, 0.05], [2,1], names=[:t, :x])
-    renamecols(t, :t => :time)
+    rename(t, :t => :time)
 """
-renamecols(t, args...) = @cols rename!(t, args...)
+rename(t, args...) = @cols rename!(t, args...)
 
-@deprecate renamecol(t, args...) renamecols(t, args...)
+@deprecate renamecol(t, args...) rename(t, args...)
 
 ## Utilities for mapping and reduction with many functions / OnlineStats
 

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -269,7 +269,7 @@ the data.
 function convertdim(x::NDSparse, d::DimName, xlat; agg=nothing, vecagg=nothing, name=nothing, select=valuenames(x))
     ks = transform(pkeys(x), d => d => xlat)
     if name !== nothing
-        ks = renamecols(ks, d => name)
+        ks = rename(ks, d => name)
     end
 
     if vecagg !== nothing

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -267,9 +267,9 @@ the data.
 `name` optionally specifies a new name for the translated dimension.
 """
 function convertdim(x::NDSparse, d::DimName, xlat; agg=nothing, vecagg=nothing, name=nothing, select=valuenames(x))
-    ks = setcol(pkeys(x), d, d=>xlat)
+    ks = transform(pkeys(x), d => d => xlat)
     if name !== nothing
-        ks = renamecol(ks, d, name)
+        ks = renamecols(ks, d => name)
     end
 
     if vecagg !== nothing

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -602,12 +602,12 @@ end
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t)
     @test insertcolsbefore(t, :x, :w => [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
     t = table([0.01, 0.05], [2, 1], names=[:t, :x])
-    @test renamecols(t, :t => :time) == table([0.01, 0.05], [2, 1], names=Symbol[:time, :x])
-    @test_throws ErrorException renamecols(t, :tt => :time)
-    @test renamecols(t, :t => :time) == renamecols(t, :t => :time)
-    @test renamecols(t, :t => :time, :x => :position) ==
+    @test rename(t, :t => :time) == table([0.01, 0.05], [2, 1], names=Symbol[:time, :x])
+    @test_throws ErrorException rename(t, :tt => :time)
+    @test rename(t, :t => :time) == rename(t, :t => :time)
+    @test rename(t, :t => :time, :x => :position) ==
         table([0.01, 0.05], [2, 1], names=Symbol[:time, :position]) ==
-        renamecols(t, (:t => :time, :x => :position))
+        rename(t, (:t => :time, :x => :position))
 end
 
 @testset "map" begin
@@ -931,7 +931,7 @@ using OnlineStats
     b = table(Columns(a=[1, 1, 2], b=[3, 2, 2], c=[4, 5, 2]), pkey=(1,2))
 
     @test groupreduce(min, a, select=3) == a
-    @test groupreduce(min, b, select=3) == renamecols(b, :c => :min)
+    @test groupreduce(min, b, select=3) == rename(b, :c => :min)
     @test_throws ArgumentError groupreduce(+, b, [:x, :y]) # issue JuliaDB.jl#100
     t = table([1, 1, 1, 2, 2, 2], [1, 1, 2, 2, 1, 1], [1, 2, 3, 4, 5, 6], names=[:x, :y, :z], pkey=(:x, :y))
     @test groupreduce(+, t, :x, select=:z) == table([1, 2], [6, 15], names=Symbol[:x, :+])
@@ -1178,7 +1178,7 @@ end
     @test groupby((:normy => x->Iterators.repeated(mean(x), length(x)),),
                   t, :x, select=:y, flatten=true) == table([1,1,2,2], [3.5,3.5,5.5,5.5], names=[:x, :normy])
     t=table([1,1,1,2,2,2], [1,1,2,1,1,2], [1,2,3,4,5,6], names=[:x,:y,:z], pkey=[1,2]);
-    @test groupby(identity, t, (:x, :y), select=:z, flatten = true) == renamecols(t, :z => :identity)
+    @test groupby(identity, t, (:x, :y), select=:z, flatten = true) == rename(t, :z => :identity)
     @test groupby(identity, t, (:x, :y), select=:z, flatten = true).pkey == [1,2]
     # If return type is non iterable, return the same as non flattened
     @test groupby(i -> (y = :y,), t, :x, flatten=true) == groupby(i -> (y = :y,), t, :x, flatten=false)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -601,6 +601,20 @@ end
     @test insertcolsafter(t, :t, :w => [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t)
     @test insertcolsbefore(t, :x, :w => [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
+
+    t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t)
+    @test insertcols(t, 2, :w => [0, 1], :z => [2, 3]) ==
+        table([0.01, 0.05], [0, 1], [2, 3], [2, 1], [3, 4], names=Symbol[:t, :w, :z, :x, :y]) ==
+        insertcols(t, 2, :w => [0, 1], :z => [2, 3])
+    t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t)
+    @test insertcolsafter(t, :t, :w => [0, 1], :z => [2, 3]) ==
+        table([0.01, 0.05], [0, 1], [2, 3], [2, 1], [3, 4], names=Symbol[:t, :w, :z, :x, :y]) ==
+        insertcolsafter(t, :t, (:w => [0, 1], :z => [2, 3]))
+    t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t)
+    @test insertcolsbefore(t, :x, :w => [0, 1], :z => [2, 3]) ==
+        table([0.01, 0.05], [0, 1], [2, 3], [2, 1], [3, 4], names=Symbol[:t, :w, :z, :x, :y]) ==
+        insertcolsbefore(t, :x, (:w => [0, 1], :z => [2, 3]))
+
     t = table([0.01, 0.05], [2, 1], names=[:t, :x])
     @test rename(t, :t => :time) == table([0.01, 0.05], [2, 1], names=Symbol[:time, :x])
     @test_throws ErrorException rename(t, :tt => :time)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -596,18 +596,18 @@ end
     @test t2 == table([4,5,6], names=[:y])
 
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t)
-    @test insertcol(t, 2, :w, [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
+    @test insertcols(t, 2, :w => [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t)
-    @test insertcolafter(t, :t, :w, [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
+    @test insertcolsafter(t, :t, :w => [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t)
-    @test insertcolbefore(t, :x, :w, [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
+    @test insertcolsbefore(t, :x, :w => [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
     t = table([0.01, 0.05], [2, 1], names=[:t, :x])
-    @test renamecol(t, :t => :time) == table([0.01, 0.05], [2, 1], names=Symbol[:time, :x])
-    @test_throws ErrorException renamecol(t, :tt => :time)
-    @test renamecol(t, :t => :time) == renamecol(t, :t => :time)
-    @test renamecol(t, :t => :time, :x => :position) ==
+    @test renamecols(t, :t => :time) == table([0.01, 0.05], [2, 1], names=Symbol[:time, :x])
+    @test_throws ErrorException renamecols(t, :tt => :time)
+    @test renamecols(t, :t => :time) == renamecols(t, :t => :time)
+    @test renamecols(t, :t => :time, :x => :position) ==
         table([0.01, 0.05], [2, 1], names=Symbol[:time, :position]) ==
-        renamecol(t, (:t => :time, :x => :position))
+        renamecols(t, (:t => :time, :x => :position))
 end
 
 @testset "map" begin
@@ -931,7 +931,7 @@ using OnlineStats
     b = table(Columns(a=[1, 1, 2], b=[3, 2, 2], c=[4, 5, 2]), pkey=(1,2))
 
     @test groupreduce(min, a, select=3) == a
-    @test groupreduce(min, b, select=3) == renamecol(b, :c => :min)
+    @test groupreduce(min, b, select=3) == renamecols(b, :c => :min)
     @test_throws ArgumentError groupreduce(+, b, [:x, :y]) # issue JuliaDB.jl#100
     t = table([1, 1, 1, 2, 2, 2], [1, 1, 2, 2, 1, 1], [1, 2, 3, 4, 5, 6], names=[:x, :y, :z], pkey=(:x, :y))
     @test groupreduce(+, t, :x, select=:z) == table([1, 2], [6, 15], names=Symbol[:x, :+])
@@ -1178,7 +1178,7 @@ end
     @test groupby((:normy => x->Iterators.repeated(mean(x), length(x)),),
                   t, :x, select=:y, flatten=true) == table([1,1,2,2], [3.5,3.5,5.5,5.5], names=[:x, :normy])
     t=table([1,1,1,2,2,2], [1,1,2,1,1,2], [1,2,3,4,5,6], names=[:x,:y,:z], pkey=[1,2]);
-    @test groupby(identity, t, (:x, :y), select=:z, flatten = true) == renamecol(t, :z => :identity)
+    @test groupby(identity, t, (:x, :y), select=:z, flatten = true) == renamecols(t, :z => :identity)
     @test groupby(identity, t, (:x, :y), select=:z, flatten = true).pkey == [1,2]
     # If return type is non iterable, return the same as non flattened
     @test groupby(i -> (y = :y,), t, :x, flatten=true) == groupby(i -> (y = :y,), t, :x, flatten=false)


### PR DESCRIPTION
This is the last part of #239, renaming `renamecol` to `renamecols` and deprecating `insertcol` to `insertcols` plus multiple columns version.

Two doubts:

1. Should the name be `renamecols` or just `rename`? After all we are obviously renaming columns (it wouldn't make to rename rows). Maybe we should just be consistent with `DataFrames` and call it `rename`.

2. I've interpreted the "multiple argument" version of `insertcols!` to behave as follows:

```julia
julia> t = table(rand(3), rand(3), rand(3), names = [:a,:b,:c])
Table with 3 rows, 3 columns:
a         b         c
────────────────────────────
0.509087  0.763431  0.557554
0.217274  0.801138  0.160908
0.462436  0.506603  0.921267

julia> insertcols(t, 2, :d => rand(3), :e => rand(3))
Table with 3 rows, 5 columns:
a         d         e         b         c
────────────────────────────────────────────────
0.509087  0.212275  0.683083  0.763431  0.557554
0.217274  0.49579   0.516921  0.801138  0.160908
0.462436  0.404024  0.982535  0.506603  0.921267

julia> insertcolsbefore(t, :c, :d => rand(3), :e => rand(3))
Table with 3 rows, 5 columns:
a         b         d          e         c
─────────────────────────────────────────────────
0.509087  0.763431  0.730766   0.263156  0.557554
0.217274  0.801138  0.844378   0.915973  0.160908
0.462436  0.506603  0.0846812  0.163381  0.921267
```

That is, we pass a unique index and all columns are inserted starting from there. I thought the version with multiple indices would be too confusing as the indices would change position when the first columns are inserted. Does this make sense?