### PR TITLE
use IndexedTables rather than StructArrays utils

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -4,8 +4,8 @@ using PooledArrays, SparseArrays, Statistics, WeakRefStrings
 
 using OnlineStatsBase: OnlineStat, fit!
 
-using StructArrays: StructVector, StructArray, foreachfield, fieldarrays,
-    collect_structarray, staticschema, ArrayInitializer, refine_perm!, collect_structarray,
+using StructArrays: StructVector, StructArray, fieldarrays,
+    staticschema, ArrayInitializer, refine_perm!, collect_structarray,
     collect_empty_structarray, grow_to_structarray!, collect_to_structarray!, replace_storage,
     GroupPerm, GroupJoinPerm, roweq, rowcmp
 

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -72,7 +72,7 @@ ncols(c::AbstractArray) = 1
 
 summary(c::Columns{D}) where {D<:Tuple} = "$(length(c))-element Columns{$D}"
 
-_sizehint!(c::Columns, n::Integer) = (foreachfield(x->_sizehint!(x,n), c); c)
+_sizehint!(c::Columns, n::Integer) = (foreach(x->_sizehint!(x,n), columns(c)); c)
 
 function _strip_pair(c::Columns{<:Pair})
     f, s = map(columns, fieldarrays(c))
@@ -91,10 +91,10 @@ end
 
 # row operations
 
-copyrow!(I::Columns, i, src) = foreachfield(c->copyelt!(c, i, src), I)
-copyrow!(I::Columns, i, src::Columns, j) = foreachfield((c1,c2)->copyelt!(c1, i, c2, j), I, src)
+copyrow!(I::Columns, i, src) = foreach(c->copyelt!(c, i, src), columns(I))
+copyrow!(I::Columns, i, src::Columns, j) = foreach((c1,c2)->copyelt!(c1, i, c2, j), columns(I), columns(src))
 copyrow!(I::AbstractArray, i, src::AbstractArray, j) = (@inbounds I[i] = src[j])
-pushrow!(to::Columns, from::Columns, i) = foreachfield((a,b)->push!(a, b[i]), to, from)
+pushrow!(to::Columns, from::Columns, i) = foreach((a,b)->push!(a, b[i]), columns(to), columns(from))
 pushrow!(to::AbstractArray, from::AbstractArray, i) = push!(to, from[i])
 
 # test that the row on the right is "as of" the row on the left, i.e.


### PR DESCRIPTION
There already is a `foreach` in IndexedTables that can do the same job as `foreachfield` from StructArrays so it's probably safer to not rely on external "utility" functions.