### PR TITLE
stop using Pair constructor

### DIFF
--- a/src/collect.jl
+++ b/src/collect.jl
@@ -56,8 +56,6 @@ function collect_columns_flattened!(dest, itr, el, st)
     return dest
 end
 
-columnspair(a::AbstractVector{S}, b::AbstractVector{T}) where {S, T} = Columns{Pair{S, T}}((a, b))
-
 function collect_columns_flattened(itr, el::Pair, st)
     fr = iterate(el.second)
     while fr === nothing
@@ -68,7 +66,8 @@ function collect_columns_flattened(itr, el::Pair, st)
     end
     dest_data = collect_columns(el.second, fr)
     dest_key = collect_columns(el.first for i in dest_data)
-    collect_columns_flattened!(columnspair(dest_key, dest_data), itr, el, st)
+    init = Columns{Pair{eltype(dest_key), eltype(dest_data)}}((dest_key, dest_data))
+    collect_columns_flattened!(init, itr, el, st)
 end
 
 function collect_columns_flattened!(dest::Columns{<:Pair}, itr, el::Pair, st)
@@ -81,5 +80,5 @@ function collect_columns_flattened!(dest::Columns{<:Pair}, itr, el::Pair, st)
         dest_data = grow_to_columns!(dest_data, el.second)
         dest_key = grow_to_columns!(dest_key, el.first for i in (n+1):length(dest_data))
     end
-    return columnspair(dest_key, dest_data)
+    return Columns{Pair{eltype(dest_key), eltype(dest_data)}}((dest_key, dest_data))
 end

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -56,6 +56,8 @@ function collect_columns_flattened!(dest, itr, el, st)
     return dest
 end
 
+columnspair(a::AbstractVector{S}, b::AbstractVector{T}) where {S, T} = Columns{Pair{S, T}}((a, b))
+
 function collect_columns_flattened(itr, el::Pair, st)
     fr = iterate(el.second)
     while fr === nothing
@@ -66,7 +68,7 @@ function collect_columns_flattened(itr, el::Pair, st)
     end
     dest_data = collect_columns(el.second, fr)
     dest_key = collect_columns(el.first for i in dest_data)
-    collect_columns_flattened!(Columns(dest_key => dest_data), itr, el, st)
+    collect_columns_flattened!(columnspair(dest_key, dest_data), itr, el, st)
 end
 
 function collect_columns_flattened!(dest::Columns{<:Pair}, itr, el::Pair, st)
@@ -79,5 +81,5 @@ function collect_columns_flattened!(dest::Columns{<:Pair}, itr, el::Pair, st)
         dest_data = grow_to_columns!(dest_data, el.second)
         dest_key = grow_to_columns!(dest_key, el.first for i in (n+1):length(dest_data))
     end
-    return Columns(dest_key => dest_data)
+    return columnspair(dest_key, dest_data)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test, IndexedTables, OnlineStats, WeakRefStrings, Tables, Random, Dates,
     TableTraits, IteratorInterfaceExtensions, Serialization, DataValues
 
 using IndexedTables: excludecols, sortpermby, primaryperm, best_perm_estimate, hascolumns,
-    collect_columns_flattened, transform
+    collect_columns_flattened, transform, columnspair
 
 include("test_tables.jl")
 include("test_missing.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test, IndexedTables, OnlineStats, WeakRefStrings, Tables, Random, Dates,
     TableTraits, IteratorInterfaceExtensions, Serialization, DataValues
 
 using IndexedTables: excludecols, sortpermby, primaryperm, best_perm_estimate, hascolumns,
-    collect_columns_flattened, transform, columnspair
+    collect_columns_flattened, transform
 
 include("test_tables.jl")
 include("test_missing.jl")

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -100,28 +100,28 @@ end
 
 @testset "collectpairs" begin
     v = (i=>i+1 for i in 1:3)
-    @test collect_columns(v) == Columns([1,2,3]=>[2,3,4])
+    @test collect_columns(v) == columnspair([1,2,3], [2,3,4])
     @test eltype(collect_columns(v)) == Pair{Int, Int}
 
     v = (i == 1 ? (1.2 => i+1) : (i => i+1) for i in 1:3)
-    @test collect_columns(v) == Columns(Real[1.2,2,3]=>[2,3,4])
+    @test collect_columns(v) == columnspair(Real[1.2,2,3], [2,3,4])
     @test eltype(collect_columns(v)) == Pair{Real, Int}
 
     v = ((a=i,) => (b="a$i",) for i in 1:3)
-    @test collect_columns(v) == Columns(Columns((a = [1,2,3],))=>Columns((b = ["a1","a2","a3"],)))
+    @test collect_columns(v) == columnspair(Columns((a = [1,2,3],)),Columns((b = ["a1","a2","a3"],)))
     @test eltype(collect_columns(v)) == Pair{NamedTuple{(:a,), Tuple{Int}}, NamedTuple{(:b,), Tuple{String}}}
 
     v = (i == 1 ? (a="1",) => (b="a$i",) : (a=i,) => (b="a$i",) for i in 1:3)
-    @test collect_columns(v) == Columns(Columns((a = ["1",2,3],))=>Columns((b = ["a1","a2","a3"],)))
+    @test collect_columns(v) == columnspair(Columns((a = ["1",2,3],)), Columns((b = ["a1","a2","a3"],)))
     @test eltype(collect_columns(v)) == Pair{NamedTuple{(:a,), Tuple{Any}}, NamedTuple{(:b,), Tuple{String}}}
 
     # empty
     v = ((a=i,) => (b="a$i",) for i in 0:-1)
-    @test collect_columns(v) == Columns(Columns((a = Int[],))=>Columns((b = String[],)))
+    @test collect_columns(v) == columnspair(Columns((a = Int[],)), Columns((b = String[],)))
     @test eltype(collect_columns(v)) == Pair{NamedTuple{(:a,), Tuple{Int}}, NamedTuple{(:b,), Tuple{String}}}
 
     v = Iterators.filter(t -> t.first.a == 4, ((a=i,) => (b="a$i",) for i in 1:3))
-    @test collect_columns(v) == Columns(Columns((a = Int[],))=>Columns((b = String[],)))
+    @test collect_columns(v) == columnspair(Columns((a = Int[],)), Columns((b = String[],)))
     @test eltype(collect_columns(v)) == Pair{NamedTuple{(:a,), Tuple{Int}}, NamedTuple{(:b,), Tuple{String}}}
 
     t = table(collect_columns((b = 1,) => (a = i,) for i in (2, missing, 3)))
@@ -130,7 +130,7 @@ end
 
 @testset "collectflattened" begin
     t = [(:a => [1, 2]), (:b => [1, 3])]
-    @test collect_columns_flattened(t) == Columns([:a, :a, :b, :b] => [1, 2, 1, 3])
+    @test collect_columns_flattened(t) == columnspair([:a, :a, :b, :b], [1, 2, 1, 3])
     t = ([(a = 1,), (a = 2,)], [(a = 1.1,), (a = 2.2,)])
     @test collect_columns_flattened(t) == Columns(a = Real[1, 2, 1.1, 2.2])
     @test eltype(collect_columns_flattened(t)) == NamedTuple{(:a,), Tuple{Real}}

--- a/test/test_collect.jl
+++ b/test/test_collect.jl
@@ -108,7 +108,7 @@ end
     @test eltype(collect_columns(v)) == Pair{Real, Int}
 
     v = ((a=i,) => (b="a$i",) for i in 1:3)
-    @test collect_columns(v) == columnspair(Columns((a = [1,2,3],)),Columns((b = ["a1","a2","a3"],)))
+    @test collect_columns(v) == columnspair(Columns((a = [1,2,3],)), Columns((b = ["a1","a2","a3"],)))
     @test eltype(collect_columns(v)) == Pair{NamedTuple{(:a,), Tuple{Int}}, NamedTuple{(:b,), Tuple{String}}}
 
     v = (i == 1 ? (a="1",) => (b="a$i",) : (a=i,) => (b="a$i",) for i in 1:3)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -1,5 +1,6 @@
 
 
+    columnspair(a::AbstractVector{S}, b::AbstractVector{T}) where {S, T} = Columns{Pair{S, T}}((a, b))
     c = Columns(([1,1,1,2,2], [1,2,4,3,5]))
     d = Columns(([1,1,2,2,2], [1,3,1,4,5]))
     e = Columns(([1,1,1], sort([rand(),0.5,rand()])))

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -10,7 +10,7 @@
     @test map_rows(i -> (exp = exp(i), log = log(i)), 1:5) == Columns((exp = exp.(1:5), log = log.(1:5)))
     @test map_rows(tuple, 1:3, ["a","b","c"]) == Columns(([1,2,3], ["a","b","c"]))
 
- c = Columns(Columns((a=[1,2,3],)) => Columns((b=["a","b","c"],)))
+ c = columnspair(Columns((a=[1,2,3],)), Columns((b=["a","b","c"],)))
     @test columns(c).first == Columns((a=[1,2,3],))
     @test columns(c).second == Columns((b=["a","b","c"],))
     @test colnames(c) == ((:a,) => (:b,))
@@ -18,17 +18,17 @@
     @test ncols(c) == (1 => 1)
     @test eltype(c) == typeof((a=1,)=>(b="a",))
     @test c[1] == ((a=1,) => (b="a",))
-    @test c[1:2] ==  Columns(Columns((a=[1,2],)) => Columns((b=["a","b"],)))
-    @test view(c, 1:2) == Columns(Columns((a=view([1,2,3],1:2),))=>Columns((b=view(["a","b","c"],1:2),)))
+    @test c[1:2] ==  columnspair(Columns((a=[1,2],)), Columns((b=["a","b"],)))
+    @test view(c, 1:2) == columnspair(Columns((a=view([1,2,3],1:2),)),Columns((b=view(["a","b","c"],1:2),)))
     d = deepcopy(c)
     d[1] = (a=2,) => (b="aa",)
     @test d[1] == ((a=2,) => (b="aa",))
     d = deepcopy(c)
     push!(d, (a=4,) => (b="d",))
-    @test d == Columns(Columns((a=[1,2,3,4],)) => Columns((b=["a","b","c","d"],)))
+    @test d == columnspair(Columns((a=[1,2,3,4],)), Columns((b=["a","b","c","d"],)))
     e = vcat(d, d)
     append!(d, d)
-    @test d == Columns(Columns((a=[1,2,3,4,1,2,3,4],)) => Columns((b=["a","b","c","d","a","b","c","d"],)))
+    @test d == columnspair(Columns((a=[1,2,3,4,1,2,3,4],)), Columns((b=["a","b","c","d","a","b","c","d"],)))
     @test d == e
     empty!(d)
     @test d == c[Int[]]
@@ -41,11 +41,11 @@
     @test issorted(c)
     @test sortperm(c) == [1,2,3]
     permute!(c, [2,3, 1])
-    @test c == Columns(Columns((a=[2,3,1],)) => Columns((b=["b","c","a"],)))
-    f = Columns(Columns(([1, 1, 2, 2],)) => ["b", "a", "c", "d"])
+    @test c == columnspair(Columns((a=[2,3,1],)), Columns((b=["b","c","a"],)))
+    f = columnspair(Columns(([1, 1, 2, 2],)), ["b", "a", "c", "d"])
     @test IndexedTables._strip_pair(f) == Columns(([1, 1, 2, 2], ["b", "a", "c", "d"]))
     @test sortperm(f) == [2, 1, 3, 4]
-    @test sort(f) == Columns(Columns(([1, 1, 2, 2],)) => ["a", "b", "c", "d"])
+    @test sort(f) == columnspair(Columns(([1, 1, 2, 2],)), ["a", "b", "c", "d"])
     @test !issorted(f)
 #end
 
@@ -1121,7 +1121,7 @@ end
 
     a = [1,2,3]
     b = ["a","b","c"]
-    v = Columns(Pair(a, b))
+    v = columnspair(a, b)
     @test convert(NDSparse, a, b) == convert(NDSparse, v) == ndsparse(v) == ndsparse(a, b)
 end
 

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -19,7 +19,7 @@
     @test eltype(c) == typeof((a=1,)=>(b="a",))
     @test c[1] == ((a=1,) => (b="a",))
     @test c[1:2] ==  columnspair(Columns((a=[1,2],)), Columns((b=["a","b"],)))
-    @test view(c, 1:2) == columnspair(Columns((a=view([1,2,3],1:2),)),Columns((b=view(["a","b","c"],1:2),)))
+    @test view(c, 1:2) == columnspair(Columns((a=view([1,2,3],1:2),)), Columns((b=view(["a","b","c"],1:2),)))
     d = deepcopy(c)
     d[1] = (a=2,) => (b="aa",)
     @test d[1] == ((a=2,) => (b="aa",))


### PR DESCRIPTION
I'm planning to remove the special `StructArray(p::Pair)` constructor (it was a bit of an odd special case), so here I'm porting IndexedTables to use the normal approach for creating a `StructArray` of pairs: `StructArray{Pair{S, T}}((a, b))`.