### PR TITLE
Removed invalid reference to 'Compat'

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -132,7 +132,7 @@ function pairs(d::NDSparse, idxs::Vararg{Any,N}) where N
     cs = astuple(columns(I))
     data = d.data
     rng = range_estimate(I, idxs)
-    (I[i]=>data[i] for i in Compat.Iterators.Filter(r->row_in(cs, r, idxs), rng))
+    (I[i]=>data[i] for i in Iterators.Filter(r->row_in(cs, r, idxs), rng))
 end
 
 # setindex!


### PR DESCRIPTION
Calling `pairs(NDSparse, idxs...)` used to throw: `ERROR: UndefVarError: Compat not defined`. This is fixed by this PR.

It might be worth noting that this did not break any test as this function is not tested.