### PR TITLE
Take special selectors from DataAPI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "6deec6e2-d858-57c5-ab9b-e6ca5bd20e43"
 version = "0.12.2"
 
 [deps]
+DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 DataValues = "e7dc6d0d-1eca-5fa6-8ad6-5aecde8b7ea5"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 IteratorInterfaceExtensions = "82899510-4779-5014-852e-03e436cf321d"
@@ -17,6 +18,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [compat]
+DataAPI = "1.0.1"
 DataValues = "0.4.6"
 IteratorInterfaceExtensions = "0.1.1, 1"
 OnlineStatsBase = "0.9.1, 0.10, 0.11, 0.12, 0.13"

--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -13,6 +13,8 @@ import Tables, TableTraits, IteratorInterfaceExtensions, TableTraitsUtils
 
 import DataValues: DataValue, DataValueArray, isna
 
+import DataAPI: Between, All
+
 import Base:
     show, eltype, length, getindex, setindex!, ndims, map, convert, keys, values,
     ==, broadcast, empty!, copy, similar, sum, merge, merge!, mapslices,

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -141,23 +141,6 @@ map_rows(f, iter) = collect_columns(f(i) for i in iter)
 ## Special selectors to simplify column selector
 
 """
-    All(cols::Union{Symbol, Int}...)
-
-Select the union of the selections in `cols`. If `cols == ()`, select all columns.
-
-# Examples
-
-    t = table([1,1,2,2], [1,2,1,2], [1,2,3,4], [0, 0, 0, 0], names=[:a,:b,:c,:d])
-    select(t, All(:a, (:b, :c)))
-    select(t, All())
-"""
-struct All{T}
-    cols::T
-end
-
-All(args...) = All(args)
-
-"""
     Not(cols::Union{Symbol, Int}...)
 
 Select the complementary of the selection in `cols`. `Not` can accept several arguments,
@@ -173,7 +156,7 @@ struct Not{T}
     cols::T
 end
 
-Not(args...) = Not(All(args))
+@deprecate Not(args...) Not(All(args...))
 
 """
     Keys()
@@ -186,21 +169,6 @@ Select the primary keys.
     select(t, Keys())
 """
 struct Keys; end
-
-"""
-    Between(first, last)
-
-Select the columns between `first` and `last`.
-
-# Examples
-
-    t = table([1,1,2,2], [1,2,1,2], 1:4, 'a':'d', names=[:a,:b,:c,:d])
-    select(t, Between(:b, :d))
-"""
-struct Between{T1 <: Union{Int, Symbol}, T2 <: Union{Int, Symbol}}
-    first::T1
-    last::T2
-end
 
 const SpecialSelector = Union{Not, All, Keys, Between, Function, Regex, Type}
 


### PR DESCRIPTION
So that IndexedTables and DataFrames can use the same special selectors. I'm leaving a buffer time with a deprecation warning for `Not` as JuliaDB accepts a multiargument version, impossible without type pirating InvertedIndices. When we drop the deprecation we can start using the InvertedIndices struct.

cc: @bkamins