### PR TITLE
update transform and Not docstring

### DIFF
--- a/src/columns.jl
+++ b/src/columns.jl
@@ -494,7 +494,7 @@ by the `AbstractVector` `value`. If `col` is not an existing column, a new colum
 
     # the column :z is not part of t so a new column is added
     t = table([0.01, 0.05], [2,1], [3,4], names=[:t, :x, :y], pkey=:t)
-    pushcol(t, :z => [1//2, 3//4])
+    transform(t, :z => [1//2, 3//4])
 """
 transform(t, args...) = @cols transform!(t, args...)
 

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -141,16 +141,18 @@ map_rows(f, iter) = collect_columns(f(i) for i in iter)
 ## Special selectors to simplify column selector
 
 """
-    Not(cols::Union{Symbol, Int}...)
+    Not(cols)
 
-Select the complementary of the selection in `cols`. `Not` can accept several arguments,
-in which case it returns the complementary of the union of the selections.
+Select the complementary of the selection in `cols`. To exclude several columns
+at the same time, use a `Tuple`. Use `Not(All(args...))` to exclude the union of
+several selections.
 
 # Examples
 
     t = table([1,1,2,2], [1,2,1,2], [1,2,3,4], names=[:a,:b,:c], pkey = (:a, :b))
     select(t, Not(:a))
-    select(t, Not(:a, (:a, :b)))
+    select(t, Not((:a, :b)))
+    select(t, Not(All(:a, (:a, :b))))
 """
 struct Not{T}
     cols::T


### PR DESCRIPTION
There was an outdated reference to `pushcol` in the `transform` docstring.