### PR TITLE
make IndexedTables compatible with StructArrays changes

### DIFF
--- a/src/collect.jl
+++ b/src/collect.jl
@@ -1,4 +1,8 @@
-const default_initializer = ArrayInitializer(t -> t<:Union{Tuple, NamedTuple, Pair}, (T, sz) -> similar(arrayof(T), sz))
+to_length(n::Integer) = n
+to_length(t::Tuple{Vararg{Integer}}) = prod(t)
+to_length(t::Tuple{Vararg{AbstractUnitRange}}) = prod(map(length, t))
+
+default_initializer(::Type{T}, sz) where {T} = similar(arrayof(T), to_length(sz))
 
 """
     collect_columns(itr)


### PR DESCRIPTION
Now StructArrays (master, unreleased) passes the actual shape of the collected iterator to the initializer (to preserve it). This makes sure that the iterator is collected as a table backed by vectors (i.e. `AbstractArray{T, 1}`).