### PR TITLE
make missing_indxs apply to AbstractVector

### DIFF
--- a/src/selection.jl
+++ b/src/selection.jl
@@ -134,7 +134,7 @@ function map(f, t::Dataset; select=nothing, copy=false, kwargs...)
 end
 
 
-missing_indxs(v::Vector) = findall(!_ismissing, v)
+missing_indxs(v::AbstractVector) = findall(!_ismissing, v)
 
 function missing_indxs(t::StructArray)
     indxs = collect(1:length(t))


### PR DESCRIPTION
This changes the type signature of missing_indxs to apply to an `AbstractVector` instead of just a `Vector`, so that it can apply to a DataValueVector (which is making the tests for JuliaDB fail on Julia 1.7).

I'm not sure why JuliaDB is using DataValueVectors instead of Vector{DataValue} on Julia 1.7 vs 1.6, but it is - applying `rows` to a chunk of a distributed table:

On 1.6:

```
julia> rows(c2, :y)
2-element DataValues.DataValueVector{Int64}:
 DataValue{Int64}()
 DataValue{Int64}(6)
```

On 1.7:

```
julia> rows(c2, :y)
2-element DataValues.DataValueVector{Int64}:
 DataValue{Int64}()
 DataValue{Int64}(6)
```

CC JuliaData/JuliaDB.jl#389

